### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,9 @@
+# Configuration for the Pull app.
+# https://github.com/wei/pull#readme
+
+version: "1"
+rules:
+  - base: develop
+    upstream: NYPL-Simplified:develop
+    mergeMethod: none
+conflictLabel: "merge-conflict"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Description
+
+<!--- Describe your changes -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have updated the documentation accordingly.
+- [ ] All new and existing tests passed.

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,87 @@
+name: Test Library Registry & Build Docker Image
+on: [push, pull_request]
+env:
+  POSTGRES_USER: simplified_test
+  POSTGRES_PASSWORD: test
+  POSTGRES_DB: simplified_registry_test
+  SIMPLIFIED_TEST_DATABASE: postgresql://simplified_test:test@localhost:5432/simplified_registry_test
+
+jobs:
+  test-library-registry:
+    name: Run Library Registry Tests
+    runs-on: ubuntu-latest
+
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. This prevents duplicated runs on internal PRs.
+    # Some discussion of this here:
+    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    services:
+      postgres:
+        image: postgis/postgis:12-3.1
+        env:
+          POSTGRES_USER: ${{ env.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ env.POSTGRES_DB }}
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Python Packages
+        run: |
+          pip install --upgrade pip
+          pip install pipenv
+          pipenv install
+
+      - name: Run Tests
+        run: pipenv run pytest -x tests
+
+  build-docker-library-registry:
+    name: Build and push library-registry docker image
+    runs-on: ubuntu-latest
+    needs: test-library-registry
+
+    # Only build docker containers on a branch push. PRs are run in the context of the repository
+    # they are made from, so they don't have the secrets necessary to push to docker hub.
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate tags for library-registry image
+        id: library-registry-tags
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: ${{ secrets.DOCKERHUB_ACCOUNT }}/library-registry
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push library-registry image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          target: libreg_prod
+          push: true
+          tags: ${{ steps.library-registry-tags.outputs.tags }}
+


### PR DESCRIPTION
## Description

This branch adds the following GitHub configuration:
- Action to run tests and build/push a docker container.
  - The Docker Hub account, username, and access token are pulled from the current GH repo's secrets. 
  - NB: The Docker Hub account name (repo namespace) is not the GH repository owner name.
- Pull bot configuration to auto PR from the `develop` branch of NYPL-Simplified/library-registry to this repo's `develop` branch.
- Pull request template.

## How Has This Been Tested?

The GitHub Action was tested in another repository to verify that it performs properly.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.