### PR TITLE
Parameterize build & add GitHub Container Registry support.

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   test-library-registry:
-    name: Run Library Registry Tests
+    name: Run Library Registry tests
     runs-on: ubuntu-latest
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
@@ -44,32 +44,67 @@ jobs:
       - name: Run Tests
         run: pipenv run pytest -x tests
 
+
+  container-build-enabled:
+    # Don't build container unless the DOCKER_REGISTRY_HOST secret is set.
+    name: Should container be built and pushed?
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ${{ secrets.DOCKER_REGISTRY_HOST }}
+    outputs:
+      enabled: ${{ steps.set-build-enabled.outputs.build_enabled }}
+    steps:
+      - id: set-build-enabled
+        run: echo "::set-output name=build_enabled::${{ toJSON(env.REGISTRY != null) }}"
+
+
   build-docker-library-registry:
     name: Build and push library-registry docker image
     runs-on: ubuntu-latest
-    needs: test-library-registry
+    needs:
+      - test-library-registry
+      - container-build-enabled
 
-    # Only build docker containers on a branch push. PRs are run in the context of the repository
-    # they are made from, so they don't have the secrets necessary to push to docker hub.
-    if: github.event_name == 'push'
+    # Only build docker containers on a branch push. PRs are run in the context of the repository from
+    # which they are made, so they don't have the secrets necessary to push to the docker registry.
+    # Also, don't run unless build/push is enabled.
+    if: github.event_name == 'push' && fromJSON(needs.container-build-enabled.outputs.enabled)
+
+    env:
+      REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}
 
     steps:
+      # If we're using GitHub Container Registry, we'll use some defaults.
+      # Otherwise, we'll use secrets from the repository.
+      - name: Setup Job Environment Variables
+        run: |
+          if [[ $REGISTRY_HOST == 'ghcr.io' ]]; then
+            echo "REGISTRY_ACCOUNT=${{ github.repository_owner }}" >> "$GITHUB_ENV"
+            echo "REGISTRY_USERNAME=${{ github.repository_owner }}" >> "$GITHUB_ENV"
+            echo "REGISTRY_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> "$GITHUB_ENV"
+          else
+            echo "REGISTRY_ACCOUNT=${{ secrets.DOCKER_REGISTRY_ACCOUNT }}" >> "$GITHUB_ENV"
+            echo "REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }}" >> "$GITHUB_ENV"
+            echo "REGISTRY_PASSWORD=${{ secrets.DOCKER_REGISTRY_TOKEN }}" >> "$GITHUB_ENV"
+          fi
+
       - uses: actions/checkout@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
+      - name: Login to Container Registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Generate tags for library-registry image
         id: library-registry-tags
         uses: crazy-max/ghaction-docker-meta@v2
         with:
-          images: ${{ secrets.DOCKERHUB_ACCOUNT }}/library-registry
+          images: ${{ env.REGISTRY_HOST }}/${{ env.REGISTRY_ACCOUNT }}/library-registry
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -84,4 +119,3 @@ jobs:
           target: libreg_prod
           push: true
           tags: ${{ steps.library-registry-tags.outputs.tags }}
-


### PR DESCRIPTION
This PR is initially for discussion. If it is accepted, I will add documentation to the README.

## Description

Parameterizes the Docker image build and adds support for pushing to GitHub Container Registry (GHCR). Container image build/push is controlled via GitHub repository secrets:
- To push to GHCR:
  - Set  `DOCKER_REGISTRY_HOST` to `ghcr.io`.
- To push to Docker Hub:
  - Set `DOCKER_REGISTRY_HOST` to `docker.io`.
  - Set `DOCKER_REGISTRY_ACCOUNT` to the Docker Hub account to which the image will be pushed.
  - Set `DOCKER_REGISTRY_USERNAME` to the name of the Docker Hub user that will be used to push the image. This user must be allowed to push images for the above account.
  - Set `DOCKER_REGISTRY_TOKEN` to a token created for this user.
 
If `DOCKER_REGISTRY_HOST` is unset, then the Docker image build/push job will not be run.

NB: Library Registry tests run in all cases.

## Motivation and Context

- Control whether container images are built and pushed.
  - An alternative might be to allow only specific GH Actions in `<repo> | Settings | Actions | Allow select actions`, but that looks rather cumbersome.
- Easily switch between pushing to Docker Hub or GHCR on a per-repo basis.
- Lay groundwork for pushing to other container registries (e.g., AWS ECR) on a per-repo basis.

## How Has This Been Tested?

Tested in fork with the following scenarios:
- `DOCKER_REGISTRY_HOST` unset.
  - Build/push job does not run. This is the expected behavior.
- `DOCKER_REGISTRY_HOST` set to `ghcr.io`, no other secrets set.
  - Build/push succeed and result in appropriately tagged images in the correct GHCR package. 
- `DOCKER_REGISTRY_HOST` set to `docker.io`, no other secrets set.
  - Build fails when attempting to log into the container registry. This is the expected behavior.
- `DOCKER_REGISTRY_HOST` set to `docker.io`, other Docker Hub secrets set appropriately.
  - Build/push succeed and result in appropriately tagged images in the correct Docker Hub repo.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
