### PR TITLE
Push Docker images to GitHub Container Repository

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -48,6 +48,10 @@ jobs:
     name: Build and push library-registry docker image
     runs-on: ubuntu-latest
     needs: test-library-registry
+    env:
+      REGISTRY_HOST: ghcr.io
+      # Don't push the Docker image if the `NO_DOCKER_IMAGE` secret is set.
+      IMAGE_PUSH_ENABLED: ${{ secrets.NO_DOCKER_IMAGE == null }}
 
     # Only build docker containers on a branch push. PRs are run in the context of the repository
     # they are made from, so they don't have the secrets necessary to push to docker hub.
@@ -59,17 +63,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
+      - name: Login to the Docker registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate tags for library-registry image
         id: library-registry-tags
         uses: crazy-max/ghaction-docker-meta@v2
         with:
-          images: ${{ secrets.DOCKERHUB_ACCOUNT }}/library-registry
+          images: ${{ env.REGISTRY_HOST }}/${{ github.repository_owner }}/library-registry
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -82,6 +87,5 @@ jobs:
           context: .
           file: ./Dockerfile
           target: libreg_prod
-          push: true
+          push: ${{ env.IMAGE_PUSH_ENABLED }}
           tags: ${{ steps.library-registry-tags.outputs.tags }}
-

--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
-# SimplyE Library Registry
+# Library Registry
 
-A geographic search engine for matching people to the libraries that serve them.
+A discovery service for matching people to the libraries that serve them.
 
-## Cloning the Registry Repositories
+[![Test Library Registry & Build Docker Image](https://github.com/ThePalaceProject/library-registry/actions/workflows/test-build.yml/badge.svg)](https://github.com/ThePalaceProject/library-registry/actions/workflows/test-build.yml)
 
-You will need both this repository and the separate front end repo in order to build the local development images. The registry front end repo must be checked out to the same directory as the `library_registry` repo itself, or you will need to change the host mount instructions in the `docker-compose.yml` file to accomodate its location. To get them both in the same parent directory, just execute:
+This is a [LYRASIS](http://lyrasis.org)-maintained fork of the NYPL [Library Simplified](http://www.librarysimplified.org/) Library Registry.
+
+Docker images ar available at:
+- https://github.com/orgs/ThePalaceProject/packages?repo_name=library-registry
+
+## Cloning the Library Registry Repositories
+
+You will need both this repository and the separate front end repo, in 
+order to build the local development images. The registry front end repo
+should be checked out into a directory named `registry_admin` in the same
+parent directory as the `library-registry` repo itself. If it is not, you
+will need to change the host mount instructions in the `docker-compose.yml`
+file to accommodate its location. To get them both in the same directory, 
+execute the following from that directory:
 
 ```shell
-git clone https://github.com/NYPL-Simplified/library_registry.git
-git clone https://github.com/NYPL-Simplified/registry_admin.git
+git clone https://github.com/ThePalaceProject/library-registry.git
+git clone https://github.com/ThePalaceProject/library-registry-admin.git registry_admin
 ```
 
 ## Installation (Docker)
@@ -22,7 +35,7 @@ _Note: If you would like to use the `Makefile` commands you will also need `make
 Local development uses two Docker images and one persistent Docker volume (for the PostgreSQL data directory). To create the base images:
 
 ```shell
-cd library_registry
+cd library-registry
 make build
 ```
 
@@ -36,7 +49,7 @@ You can start up the local compose cluster in the background with:
 make up
 ```
 
-Alternatively, if you want to keep a terminal attached to the running containers so you can see their output, use:
+Alternatively, if you want to keep a terminal attached to the running containers, so you can see their output, use:
 
 ```shell
 make up-watch


### PR DESCRIPTION
## Description

This branch
- Switches the Docker image build to use GitHub Container Registry (GHCR), instead of Docker Hub.
  - If a secret named `NO_DOCKER_IMAGE` is set (to anything), then the Docker image will not be pushed to the registry and message like the following will appear in the action log:
    `time="2021-05-07T23:14:41Z" level=warning msg="No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load"`
- Updates the README to add a badge, update instructions for the new repository and Docker image homes, and do a little clean up.

## Motivation and Context

- Simplify Docker builds by moving to GHCR.
- Provide an option to avoid accumulation of unnecessary Docker images.

## How Has This Been Tested?

Tested in fork with secret set and unset. In both cases, it worked as expected.

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
