### PR TITLE
Use specified SMTP host and port

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -2,7 +2,7 @@ from email import charset
 from email.header import Header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import smtplib
+from smtplib import SMTP
 
 from config import CannotLoadConfiguration
 
@@ -165,13 +165,12 @@ The link will expire in about a day. If the link expires, just re-register your 
                 )
 
 
-    def send(self, email_type, to_address, smtp=None, **kwargs):
+    def send(self, email_type: str, to_address: str, smtp_class=SMTP, **kwargs):
         """Generate an email from a template and send it.
 
         :param email_type: The name of the template to use.
         :param to_address: Addressee of the email.
-        :param smtp: Use this object as a mock instead of creating an
-            smtplib.SMTP object.
+        :param smtp_class: Use this class for the SMTP protocol client.
         :param kwargs: Arguments to use when generating the email from
             a template.
         """
@@ -182,11 +181,11 @@ The link will expire in about a day. If the link expires, just re-register your 
         kwargs['from_address'] = self.from_address
         kwargs['to_address'] = to_address
         body = template.body(from_header, to_address, **kwargs)
-        return self._send_email(to_address, body, smtp)
+        return self._send_email(to_address, body, smtp_class)
 
-    def _send_email(self, to_address, body, smtp=None):
+    def _send_email(self, to_address, body, smtp_class=SMTP):
         """Actually send an email."""
-        smtp = smtp or smtplib.SMTP(host=self.smtp_host, port=self.smtp_port)
+        smtp = smtp_class(host=self.smtp_host, port=self.smtp_port)
         smtp.connect(self.smtp_host, self.smtp_port)
         smtp.starttls()
         smtp.login(self.smtp_username, self.smtp_password)

--- a/emailer.py
+++ b/emailer.py
@@ -1,9 +1,11 @@
+from email import charset
 from email.header import Header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email import charset
-import email
 import smtplib
+
+from config import CannotLoadConfiguration
+
 
 # Set up an encoding/decoding between UTF-8 and quoted-printable.
 # Otherwise, the bodies of email messages will be encoded with base64
@@ -11,9 +13,6 @@ import smtplib
 # need to be encoded.
 charset.add_charset('utf-8', charset.QP, charset.QP, 'utf-8')
 
-from config import (
-    CannotLoadConfiguration,
-)
 
 
 class Emailer(object):

--- a/emailer.py
+++ b/emailer.py
@@ -187,7 +187,7 @@ The link will expire in about a day. If the link expires, just re-register your 
 
     def _send_email(self, to_address, body, smtp=None):
         """Actually send an email."""
-        smtp = smtp or smtplib.SMTP()
+        smtp = smtp or smtplib.SMTP(host=self.smtp_host, port=self.smtp_port)
         smtp.connect(self.smtp_host, self.smtp_port)
         smtp.starttls()
         smtp.login(self.smtp_username, self.smtp_password)

--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -1,14 +1,11 @@
+from email.mime.text import MIMEText
+import quopri
+
 import pytest
 
 from . import DatabaseTest
-from email.mime.text import MIMEText
-
 from config import CannotLoadConfiguration
-from emailer import (
-    Emailer,
-    EmailTemplate,
-)
-import quopri
+from emailer import Emailer, EmailTemplate
 
 
 class TestEmailTemplate(object):


### PR DESCRIPTION
## Description

This branch changes the `Emailer` so that it initializes its SMTP client with the specified host and port. The branch also:
- Refactors `Emailer` methods and associated tests to verify SMTP client init.
- Cleans up imports for both emailer.py and its associated test module.

## Motivation and Context

The SMTP client was being initialized with its defaults, even when host and port were configured. This prevented that client from working properly in all but the default configuration.

## How Has This Been Tested?

Manually tested to verify that host and port are used. Added/updated tests to verify proper initialization. Ran all new and existing tests.

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
