### PR TITLE
Fix originating ip when proxied

### DIFF
--- a/tests/util/test_flask_util.py
+++ b/tests/util/test_flask_util.py
@@ -1,0 +1,23 @@
+from flask import Flask
+import pytest
+
+from util.flask_util import originating_ip
+
+
+app = Flask(__name__)
+
+
+@pytest.mark.parametrize(
+    'expected_address, remote_address, headers', [
+        ('192.168.1.10', '192.168.1.10', {}),
+        ('192.168.1.10', '192.168.1.10', {'X-Forwarded-For': ''}),
+        ('192.168.2.20', '192.168.1.10', {'X-Forwarded-For': '192.168.2.20'}),
+        ('192.168.2.20', '192.168.1.10', {'X-Forwarded-For': '192.168.2.20,192.168.1.20'}),
+        ('192.168.2.20', '192.168.1.10', {'x-forwarded-for': '192.168.2.20, 192.168.1.20'}),
+        ('192.168.2.20', '192.168.1.10', {'x-forwarded-for': '192.168.2.20, 192.168.1.20, 192.168.1.10'}),
+    ])
+def test_originating_ip(expected_address, remote_address, headers):
+    with app.test_request_context('url', headers=headers, environ_base={'REMOTE_ADDR': remote_address}):
+        result_address = originating_ip()
+
+    assert result_address == expected_address

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -1,12 +1,15 @@
 """Utilities for Flask applications."""
+import re
+
 import flask
 from flask import Response
 
-from . import (
-    problem_detail,
-)
-
+from . import problem_detail
 from .language import languages_from_accept
+
+
+_COMMA_SPACE_SEPARATOR = re.compile(r'\s*,\s*')
+
 
 def problem_raw(type, status, title, detail=None, instance=None, headers={}):
     data = problem_detail.json(type, status, title, detail, instance)
@@ -23,15 +26,17 @@ def problem(type, status, title, detail=None, instance=None, headers={}):
 def languages_for_request():
     return languages_from_accept(flask.request.accept_languages)
 
-def originating_ip():
-    """If there is an X-Forwarded-For header, use its value as the
-    originating IP address. Otherwise, use the address that originated
-    this request.
+def originating_ip() -> str:
+    """Determine the client's IP address.
+
+    If there is an X-Forwarded-For header and it has a non-empty value,
+    use the client value as the originating IP address. Otherwise, use
+    the address that originated this request.
+
+    NB: The format of an X-Forwarded-For header value is: "<client-ip>, [proxy1-ip, [proxy2ip ...]]
+
+    :return: IP address of request originator
+    :rtype: str
     """
-    address = None
-    header = 'X-Forwarded-For'
-    if header in flask.request.headers:
-        address = flask.request.headers[header]
-    if not address:
-        address = flask.request.remote_addr
-    return address
+    addresses = re.split(_COMMA_SPACE_SEPARATOR, flask.request.headers.get('X-Forwarded-For', '').strip())
+    return addresses[0] or flask.request.remote_addr

--- a/util/flask_util.py
+++ b/util/flask_util.py
@@ -1,14 +1,10 @@
 """Utilities for Flask applications."""
-import re
 
 import flask
 from flask import Response
 
 from . import problem_detail
 from .language import languages_from_accept
-
-
-_COMMA_SPACE_SEPARATOR = re.compile(r'\s*,\s*')
 
 
 def problem_raw(type, status, title, detail=None, instance=None, headers={}):
@@ -38,5 +34,5 @@ def originating_ip() -> str:
     :return: IP address of request originator
     :rtype: str
     """
-    addresses = re.split(_COMMA_SPACE_SEPARATOR, flask.request.headers.get('X-Forwarded-For', '').strip())
-    return addresses[0] or flask.request.remote_addr
+    forwarded_for_client_ip = next(map(str.strip, flask.request.headers.get('X-Forwarded-For', '').split(',')))
+    return forwarded_for_client_ip or flask.request.remote_addr


### PR DESCRIPTION
## Description

Fixes lookup of originating client IP address when Library Registry access is proxied (i.e., when an `X-Forwarded-For` header is present and contains more than one IP address). It also adds tests that include a representative set of cases for that header and its absence.

## Motivation and Context

`originating_ip` previously assumed that `X-Forwarded-For` would contain a single IP address, when present. This is not the case when running behind an AWS load balancer.

## How Has This Been Tested?

Ran existing and new tests. Deployed  a development branch container with this fix into a development environment behind an AWS load balancer and manually tested problem path.

## Checklist:

- [N/A] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
