### PR TITLE
Allow recipient override from environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ git clone https://github.com/thepalaceproject/library-registry.git
 git clone https://github.com/thepalaceproject/library-registry-admin.git
 ```
 
+## Key Environment Variables
+
+These environment variables are generally applicable, regardless of installation method, and are included here because they are not discussed elsewhere in this document.
+
+- EMAILER_RECIPIENT_OVERRIDE: If set, `emailer` will send all non-test email to this email address.
+
 ## Installation (Docker)
 
 Because the Registry runs in a Docker container, the only required software is [Docker Desktop](https://www.docker.com/products/docker-desktop). The database and webapp containers expect to be able to operate on ports 5432 and 80, respectively--if those ports are in use already you may need to amend the `docker-compose.yml` file to add alternate ports.


### PR DESCRIPTION
## Description

Add the ability to override the usual recipient address for a given email via an environment variable. When the environment variable is set, all non-`test` emails will be sent to this address.

## Motivation and Context

In hosted environments, especially during mass migration of libraries from one registry to another, it might not be appropriate to send registration-related emails to customer libraries. This functionality enables a hosting provider to direct these emails to an address they control.

## How Has This Been Tested?

New tests that verify the functionality. Additional testing will be performed upon initial deployment.

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
