### PR TITLE
Allow Vendor ID without delegate.

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -611,9 +611,8 @@ class ConfigureVendorIDScript(Script):
             "--node-value", help="Node value issued by Adobe", required=True
         )
         parser.add_argument(
-            "--delegate",
+            "--delegate", action="append", default=[],
             help="Delegate Adobe IDs to this URL if no local answer found",
-            action="append"
         )
         return parser
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -521,6 +521,23 @@ class TestConfigureVendorIDScript(DatabaseTest):
         assert integration.setting(Configuration.ADOBE_VENDOR_ID_NODE_VALUE).value == "abc12"
         assert integration.setting(Configuration.ADOBE_VENDOR_ID_DELEGATE_URL).json_value == ["http://server1/AdobeAuth/", "http://server2/AdobeAuth/"]
 
+        # It's okay to configure without a delegate.
+        cmd_args = [
+            "--vendor-id=VENDOR",
+            "--node-value=133715d34d",
+        ]
+        script = ConfigureVendorIDScript(self._db)
+        script.do_run(self._db, cmd_args=cmd_args)
+
+        # The ExternalIntegration is properly configured.
+        integration = ExternalIntegration.lookup(
+            self._db, ExternalIntegration.ADOBE_VENDOR_ID,
+            ExternalIntegration.DRM_GOAL
+        )
+        assert integration.setting(Configuration.ADOBE_VENDOR_ID).value == "VENDOR"
+        assert integration.setting(Configuration.ADOBE_VENDOR_ID_NODE_VALUE).value == "133715d34d"
+        assert integration.setting(Configuration.ADOBE_VENDOR_ID_DELEGATE_URL).json_value == []
+
         # The script won't run if --node-value or --delegate have obviously
         # wrong values.
         cmd_args = [


### PR DESCRIPTION
## Description

- Updates the Adobe Vendor ID configuration script to allow invocation without a `delegate` URL.
- Adds test for running script without specifying a `delegate` URL.

## Motivation and Context

It will be appropriate to run without a delegate in some scenarios, so the configuration scripts should support that.

## How Has This Been Tested?

- Added new test to validate this use case.
- Ran all tests.

## Checklist:

- [N/A] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
