### PR TITLE
Propagate the URL scheme from upstream proxy.

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,7 +46,7 @@ http {
 
         location @proxy_to_app {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
             proxy_set_header Host $http_host;
             proxy_redirect off;
             proxy_pass http://library-registry-server;


### PR DESCRIPTION
## Description

Propagates the URL scheme from an upstream proxy, if present.

## Motivation and Context

The Library Registry service runs behind an upstream proxy in its Docker container. When an additional proxy (e.g., AWS ALB) is introduced upstream, the original URL scheme was not propagated to the Flask app and scheme used between the two proxies was used, instead. This could result in the Library Registry generating incorrect URLs for its services. This, in turn could result in HTTP 301 redirects, which were not correctly handled on POST requests for some clients (e.g., Python `requests` library). 

## How Has This Been Tested?

Manual testing, including successful registration of two Palace QA libraries.

## Checklist:

- [N/A] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
