### PR TITLE
Fix for dependabot PRs failing CI.

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -115,7 +115,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
         if: env.IMAGE_PUSH_ENABLED == 'true'
 
-      - name: Generate tags for library-registry image
+      - name: Generate tags
         id: library-registry-tags
         uses: docker/metadata-action@v3
         with:
@@ -126,7 +126,7 @@ jobs:
             type=ref,event=branch,priority=30
             type=sha,priority=40
 
-      - name: Build and push library-registry image
+      - name: Build image
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -82,17 +82,24 @@ jobs:
         run: tox
 
   build:
-    name: Build and push docker image
+    name: Docker build
     runs-on: ubuntu-latest
     needs: [lint, test]
     env:
       REGISTRY_HOST: ghcr.io
-      # Don't push the Docker image if the `NO_DOCKER_IMAGE` secret is set.
-      IMAGE_PUSH_ENABLED: ${{ secrets.NO_DOCKER_IMAGE == null }}
 
-    # Only build docker containers on a branch push. PRs are run in the context of the repository
-    # they are made from, so they don't have the secrets necessary to push to docker hub.
-    if: github.event_name == 'push'
+      # Push the built docker image only in the following cases:
+      #  - The `NO_DOCKER_IMAGE` secret is not set. (Useful if you want to disable pushing
+      #    of docker images in local forks of this repo).
+      #  - The branch name does not start with `dependabot/`. The dependabot service doesn not
+      #    have the proper security token to push to github packages.
+      #  - The event that triggered this action was a `push`. If it was a PR the github action
+      #    context will not have permissions to push the image to github packages.
+      IMAGE_PUSH_ENABLED: ${{
+          secrets.NO_DOCKER_IMAGE == null &&
+          !startsWith(github.ref, 'refs/heads/dependabot/') &&
+          github.event_name == 'push'
+        }}
 
     steps:
       - uses: actions/checkout@v2
@@ -106,6 +113,7 @@ jobs:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ env.IMAGE_PUSH_ENABLED }}
 
       - name: Generate tags for library-registry image
         id: library-registry-tags

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -113,7 +113,7 @@ jobs:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ env.IMAGE_PUSH_ENABLED }}
+        if: env.IMAGE_PUSH_ENABLED == 'true'
 
       - name: Generate tags for library-registry image
         id: library-registry-tags

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -91,7 +91,7 @@ jobs:
       # Push the built docker image only in the following cases:
       #  - The `NO_DOCKER_IMAGE` secret is not set. (Useful if you want to disable pushing
       #    of docker images in local forks of this repo).
-      #  - The branch name does not start with `dependabot/`. The dependabot service doesn not
+      #  - The branch name does not start with `dependabot/`. The dependabot service does not
       #    have the proper security token to push to github packages.
       #  - The event that triggered this action was a `push`. If it was a PR the github action
       #    context will not have permissions to push the image to github packages.


### PR DESCRIPTION
## Description

Modify the docker container part of our CI to not push container images from branches created by Dependabot for security updates. This PR changes the build process to still build the container, so we see that the build works, but it won't push the build out to github packages. 

This also updates what we do on a PR from an external repo. In that case, we also build the docker container, to make sure the changes don't break the docker build, but we don't push the resulting docker image to github packages.

## Motivation and Context

Github actions run by a PR from dependabot are run with read only permissions on the `GITHUB_TOKEN`, so they are failing the push docker image part of CI. 

See build here for an example of the failure we were seeing: 
https://github.com/ThePalaceProject/library-registry/runs/3446427939

## How Has This Been Tested?

I did some testing with github actions on my fork of this project.