### PR TITLE
HELP rel links may now also be http[s]:// links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: Run black
@@ -51,7 +51,7 @@ repos:
         files: pyproject.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.3
+    rev: 0.9.3
     hooks:
       - id: pymarkdown
         args: [--disable-version, -c, .pymarkdown.config.json, scan]

--- a/model.py
+++ b/model.py
@@ -1879,6 +1879,10 @@ class Hyperlink(Base):
         if to_address.startswith("mailto:"):
             to_address = to_address[7:]
 
+        # Are we an email address type of link
+        if not re.match(r"[^@]+@.+", to_address):
+            return
+
         # Make sure there's a Validation object associated with this
         # Resource.
         if resource.validation is None:

--- a/tests/test_util_string_helpers.py
+++ b/tests/test_util_string_helpers.py
@@ -10,7 +10,7 @@ from util.string_helpers import UnicodeAwareBase64, base64, random_string
 
 class TestUnicodeAwareBase64(object):
     def test_encoding(self):
-        test_string = u"םולש"
+        test_string = "םולש"
 
         # Run the same tests against two different encodings that can
         # handle Hebrew characters.
@@ -62,7 +62,7 @@ class TestUnicodeAwareBase64(object):
         # UnicodeAwareBase64 object that encodes as UTF-8 by default.
         assert isinstance(base64, UnicodeAwareBase64)
         assert base64.encoding == "utf8"
-        snowman = u"☃"
+        snowman = "☃"
         snowman_utf8 = snowman.encode("utf8")
         as_base64 = base64.b64encode(snowman)
         assert as_base64 == "4piD"


### PR DESCRIPTION
## Description
A side-effect of this is that in case both http and mailto links
are present as a HELP rel, only the first one in the document will be used
This is an intended behaviour in the codebase

Also fixed pre-commit issues

<!--- Describe your changes -->

## Motivation and Context
Some libraries prefer to have help websites rather than contact emails. This change is to facilitate that on the Library-registry
[Notion](https://www.notion.so/lyrasis/Library-Registry-changes-to-support-registration-of-non-mailto-help-URLs-973d588ee4a5422b973c7894279c3060)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
