### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -5,6 +5,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +41,9 @@ jobs:
     name: Docker build
     runs-on: ubuntu-latest
     needs: [test]
+    permissions:
+      contents: read
+      packages: write
     env:
       REGISTRY_HOST: ghcr.io
 


### PR DESCRIPTION
## Description

When Dependabot pushes branches, or automatically merges PRs, it currently doesn't have permissions to create docker images, causing builds to fail.

This PR mirrors these changes in circulation: 
https://github.com/ThePalaceProject/circulation/pull/171

## Motivation and Context

Dependabot is by default given only read permissions on repositories, but it respects the repos `permissions` set in the workflow [[1]](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/). In order to be able to push docker images it needs `packages: write` permission. 

You can set explicit workflow permissions by setting a permissions key in the workflows [[2]](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/). Setting these should actually be more secure then our previous configuration, as the defaults are quite permissive. 

## How Has This Been Tested?

Since this is scoped to our actions workflows, the CI passing on this PR should give confidence this is working.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
