### PR TITLE
Admin and secret key auth implemented for endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,10 +8,9 @@ from flask_babel import Babel
 from flask_sqlalchemy_session import flask_scoped_session
 
 from app_helpers import (
-    auth_admin_only,
-    auth_secret_key,
     compressible,
     has_library_factory,
+    require_admin_authentication,
     uses_location_factory,
 )
 from config import Configuration
@@ -93,7 +92,6 @@ def nearby_qa(_location):
 
 
 @app.route("/register", methods=["GET", "POST"])
-@auth_secret_key
 @returns_problem_detail
 def register():
     return app.library_registry.registry_controller.register()
@@ -150,56 +148,56 @@ def log_out():
 
 
 @app.route("/admin/libraries")
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def libraries():
     return app.library_registry.registry_controller.libraries()
 
 
 @app.route("/admin/libraries/qa")
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def libraries_qa_admin():
     return app.library_registry.registry_controller.libraries(live=False)
 
 
 @app.route("/admin/libraries/<uuid>")
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def library_details(uuid):
     return app.library_registry.registry_controller.library_details(uuid)
 
 
 @app.route("/admin/libraries/search_details", methods=["POST"])
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def search_details():
     return app.library_registry.registry_controller.search_details()
 
 
 @app.route("/admin/libraries/email", methods=["POST"])
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def validate_email():
     return app.library_registry.registry_controller.validate_email()
 
 
 @app.route("/admin/libraries/registration", methods=["POST"])
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def edit_registration():
     return app.library_registry.registry_controller.edit_registration()
 
 
 @app.route("/admin/libraries/pls_id", methods=["POST"])
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def pls_id():
     return app.library_registry.registry_controller.add_or_edit_pls_id()
 
 
 @app.route("/admin/secret_key")
-@auth_admin_only
+@require_admin_authentication
 @returns_json_or_response_or_problem_detail
 def admin_secret_key():
     """Admin view for the registry secret key"""

--- a/app.py
+++ b/app.py
@@ -7,7 +7,13 @@ from flask import Flask, Response
 from flask_babel import Babel
 from flask_sqlalchemy_session import flask_scoped_session
 
-from app_helpers import compressible, has_library_factory, uses_location_factory
+from app_helpers import (
+    auth_admin_only,
+    auth_secret_key,
+    compressible,
+    has_library_factory,
+    uses_location_factory,
+)
 from config import Configuration
 from controller import LibraryRegistry
 from log import LogConfiguration
@@ -87,6 +93,7 @@ def nearby_qa(_location):
 
 
 @app.route("/register", methods=["GET", "POST"])
+@auth_secret_key
 @returns_problem_detail
 def register():
     return app.library_registry.registry_controller.register()
@@ -143,45 +150,64 @@ def log_out():
 
 
 @app.route("/admin/libraries")
+@auth_admin_only
 @returns_json_or_response_or_problem_detail
 def libraries():
     return app.library_registry.registry_controller.libraries()
 
 
 @app.route("/admin/libraries/qa")
+@auth_admin_only
 @returns_json_or_response_or_problem_detail
 def libraries_qa_admin():
     return app.library_registry.registry_controller.libraries(live=False)
 
 
 @app.route("/admin/libraries/<uuid>")
+@auth_admin_only
 @returns_json_or_response_or_problem_detail
 def library_details(uuid):
     return app.library_registry.registry_controller.library_details(uuid)
 
 
 @app.route("/admin/libraries/search_details", methods=["POST"])
+@auth_admin_only
 @returns_json_or_response_or_problem_detail
 def search_details():
     return app.library_registry.registry_controller.search_details()
 
 
 @app.route("/admin/libraries/email", methods=["POST"])
+@auth_admin_only
 @returns_json_or_response_or_problem_detail
 def validate_email():
     return app.library_registry.registry_controller.validate_email()
 
 
 @app.route("/admin/libraries/registration", methods=["POST"])
+@auth_admin_only
 @returns_json_or_response_or_problem_detail
 def edit_registration():
     return app.library_registry.registry_controller.edit_registration()
 
 
 @app.route("/admin/libraries/pls_id", methods=["POST"])
+@auth_admin_only
 @returns_json_or_response_or_problem_detail
 def pls_id():
     return app.library_registry.registry_controller.add_or_edit_pls_id()
+
+
+@app.route("/admin/secret_key")
+@auth_admin_only
+@returns_json_or_response_or_problem_detail
+def admin_secret_key():
+    """Admin view for the registry secret key"""
+    return dict(
+        secret_key=app.secret_key,
+        details="Share this key with authorized clients.",
+        usage="Append the secret key as a parameter to required urls. Eg. /register?secret_key=....",
+    )
 
 
 @app.route("/library/<uuid>")

--- a/app.py
+++ b/app.py
@@ -196,18 +196,6 @@ def pls_id():
     return app.library_registry.registry_controller.add_or_edit_pls_id()
 
 
-@app.route("/admin/secret_key")
-@require_admin_authentication
-@returns_json_or_response_or_problem_detail
-def admin_secret_key():
-    """Admin view for the registry secret key"""
-    return dict(
-        secret_key=app.secret_key,
-        details="Share this key with authorized clients.",
-        usage="Append the secret key as a parameter to required urls. Eg. /register?secret_key=....",
-    )
-
-
 @app.route("/library/<uuid>")
 @has_library
 @returns_json_or_response_or_problem_detail

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -110,3 +110,32 @@ def compressible(f):
         return f(*args, **kwargs)
 
     return compressor
+
+
+def auth_admin_only(func):
+    """Test authentication on the request.
+    The request session should have previously authenticatated as an admin."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if "username" in flask.session and flask.session["username"] is not None:
+            return func(*args, **kwargs)
+        else:
+            return flask.Response(response="Unauthorized", status=401)
+
+    return wrapper
+
+
+def auth_secret_key(func):
+    """Test secret key authentication on the request.
+    The secret key is a shared secret, and must be available to authorized clients."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        secret_key = flask.request.args.get("secret_key")
+        if secret_key == flask.current_app.secret_key:
+            return func(*args, **kwargs)
+        else:
+            return flask.Response(response="Unauthorized", status=401)
+
+    return wrapper

--- a/app_helpers.py
+++ b/app_helpers.py
@@ -125,8 +125,7 @@ def require_admin_authentication(func):
                 .filter(Admin.username == flask.session["username"])
                 .first()
             )
-            print(admin)
-            print(flask.current_app._db.query(Admin).all())
+
             if admin:
                 return func(*args, **kwargs)
 


### PR DESCRIPTION
## Description
Admin auth depends on the user having logged in as an admin in the same session. 
Secret key auth depends on the secret_key parameter being present on the url.

The secret key auth is using an already available sitewide secret key, which does not seem to be used anywhere else in the application.
It was just being created, and kept in the database for some reason.
A new endpoint has been added to display the secret key so it can be used, this endpoint is admin authenticated.
`/admin/secret_key`

All `/admin/...` endpoints are admin authenticated now.

<!--- Describe your changes -->

## Motivation and Context
The library registry APIs had no authentication built into the endpoints. 
This is required to avoid arbitrary library registrations.
[Notion](https://www.notion.so/lyrasis/Library-Registry-API-Security-8a4ef090d2eb48fcb521a3c95c8fd4e7)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manual testing was done via Postman for the `/register` URL and via the browser for the `/admin` URLs.
Unit tests have been updated to test the authentication methods
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
