### PR TITLE
Initial alembic integration

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,107 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python-dateutil library that can be
+# installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+timezone = UTC
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# This will be pulled dynamically from the env.py file
+# sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,3 +1,4 @@
+import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
@@ -52,7 +53,7 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    url = Configuration.database_url()
+    url = Configuration.database_url("TESTING" in os.environ)
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -76,7 +77,7 @@ def run_migrations_online() -> None:
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
-        **{"url": Configuration.database_url()}
+        **{"url": Configuration.database_url("TESTING" in os.environ)}
     )
 
     with connectable.connect() as connection:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,99 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+from config import Configuration
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+from model import Base
+
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def include_name(name, type_, parent_name):
+    """
+    Items we want to ignore during autogeneration
+    - Table spatial_ref_sys: This is generated and managed by the postgis extension
+    """
+    if type_ == "table":
+        return name not in {
+            "spatial_ref_sys",
+        }
+    return True
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = Configuration.database_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        include_name=include_name,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        **{"url": Configuration.database_url()}
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            include_name=include_name,
+        )
+
+        with context.begin_transaction():
+            # Acquire an application lock to ensure multiple migrations are queued and not concurrent
+            # See: https://github.com/sqlalchemy/alembic/issues/633
+            connection.execute("SELECT pg_advisory_xact_lock(10000);")
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/app.py
+++ b/app.py
@@ -1,15 +1,5 @@
 """Library registry web application."""
 import os
-
-## Before we do anything, we must run the database migrations
-## It is important this runs before ANY models are imported
-## or the SQLAlchemy session is initialized
-from db_migration import migrate
-
-# Only migrate if we're not in a testing environment
-if "TESTING" not in os.environ:
-    migrate()
-
 import sys
 import urllib.parse
 
@@ -42,7 +32,7 @@ uses_location = uses_location_factory(app)
 
 testing = "TESTING" in os.environ
 db_url = Configuration.database_url(testing)
-SessionManager.initialize(db_url)
+SessionManager.initialize(db_url, testing=testing)
 session_factory = SessionManager.sessionmaker(db_url)
 _db = flask_scoped_session(session_factory, app)
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,12 @@
 """Library registry web application."""
+
+## Before we do anything, we must run the database migrations
+## It is important this runs before ANY models are imported
+## or the SQLAlchemy session is initialized
+from db_migration import migrate
+
+migrate()
+
 import os
 import sys
 import urllib.parse

--- a/app.py
+++ b/app.py
@@ -1,13 +1,15 @@
 """Library registry web application."""
+import os
 
 ## Before we do anything, we must run the database migrations
 ## It is important this runs before ANY models are imported
 ## or the SQLAlchemy session is initialized
 from db_migration import migrate
 
-migrate()
+# Only migrate if we're not in a testing environment
+if "TESTING" not in os.environ:
+    migrate()
 
-import os
 import sys
 import urllib.parse
 

--- a/db_migration.py
+++ b/db_migration.py
@@ -17,6 +17,7 @@ def migrate():
     Note: This function must be run before the SQLAlchemy session is initialized.
     """
     log = logging.getLogger(__name__)
+    logging.basicConfig()
     log.setLevel(logging.INFO)
 
     # Find the 'libraries' table
@@ -26,9 +27,9 @@ def migrate():
     cursor.execute("SELECT * FROM pg_catalog.pg_tables where tablename='libraries';")
     table_row = cursor.fetchone()
     cursor.close()
+    conn.close()
 
     alembic_cfg = Config("alembic.ini")
-    alembic_cfg.set_main_option("url", db_url)
     if table_row is None:
         # We have no libraries table setup, this is the first ever run.
         # SqlAlchemy will create all tables, simply stamp the head.

--- a/db_migration.py
+++ b/db_migration.py
@@ -38,7 +38,7 @@ def migrate(db_url: str):
         )
         try:
             stamp(alembic_cfg, "head")
-        except CommandError as ex:
+        except (CommandError, FileNotFoundError) as ex:
             # Alembic log config disables other logs
             log.disabled = False
             log.error(f"Alembic Error: Could not run STAMP HEAD on the database")
@@ -49,7 +49,7 @@ def migrate(db_url: str):
         log.info("Running alembic upgrade.")
         try:
             upgrade(alembic_cfg, "head")
-        except CommandError as ex:
+        except (CommandError, FileNotFoundError) as ex:
             # Alembics log config disables other logs
             log.disabled = False
             log.error(f"Alembic Error: Could not run UPGRADE HEAD on the database")

--- a/db_migration.py
+++ b/db_migration.py
@@ -25,6 +25,7 @@ def migrate():
     cursor = conn.cursor()
     cursor.execute("SELECT * FROM pg_catalog.pg_tables where tablename='libraries';")
     table_row = cursor.fetchone()
+    cursor.close()
 
     alembic_cfg = Config("alembic.ini")
     alembic_cfg.set_main_option("url", db_url)

--- a/db_migration.py
+++ b/db_migration.py
@@ -1,0 +1,42 @@
+# In order to keep the DB from initializing accidentally we do not import any other part of the application in this file
+import logging
+import os
+
+import psycopg2
+
+from alembic.command import stamp, upgrade
+from alembic.config import Config
+
+
+def migrate():
+    """Ensure the alembic migration state is up-to-date.
+    If the database table "libraries" has not been created yet, we can assume this is a new deployment.
+    Else, we can assume this database should attempt an upgrade to the latest version, if the DB
+    is already at the latest version, alembic will ignore the upgrade command.
+
+    Note: This function must be run before the SQLAlchemy session is initialized.
+    """
+    log = logging.getLogger(__name__)
+    log.setLevel(logging.INFO)
+
+    # Find the 'libraries' table
+    db_url = os.environ.get("SIMPLIFIED_PRODUCTION_DATABASE")
+    conn = psycopg2.connect(db_url)
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM pg_catalog.pg_tables where tablename='libraries';")
+    table_row = cursor.fetchone()
+
+    alembic_cfg = Config("alembic.ini")
+    alembic_cfg.set_main_option("url", db_url)
+    if table_row is None:
+        # We have no libraries table setup, this is the first ever run.
+        # SqlAlchemy will create all tables, simply stamp the head.
+        log.info(
+            "Database tables were not detected, stamping the alembic version to 'head'."
+        )
+        stamp(alembic_cfg, "head")
+    else:
+        # This is not a new deployment, run the 'upgrade head' command.
+        # This is an idempotent command, we don't have to check whether it needs to be run or not.
+        log.info("Running alembic upgrade.")
+        upgrade(alembic_cfg, "head")

--- a/db_migration.py
+++ b/db_migration.py
@@ -1,6 +1,4 @@
-# In order to keep the DB from initializing accidentally we do not import any other part of the application in this file
 import logging
-import os
 
 import psycopg2
 
@@ -8,7 +6,7 @@ from alembic.command import stamp, upgrade
 from alembic.config import Config
 
 
-def migrate():
+def migrate(db_url: str):
     """Ensure the alembic migration state is up-to-date.
     If the database table "libraries" has not been created yet, we can assume this is a new deployment.
     Else, we can assume this database should attempt an upgrade to the latest version, if the DB
@@ -21,7 +19,6 @@ def migrate():
     log.setLevel(logging.INFO)
 
     # Find the 'libraries' table
-    db_url = os.environ.get("SIMPLIFIED_PRODUCTION_DATABASE")
     conn = psycopg2.connect(db_url)
     cursor = conn.cursor()
     cursor.execute("SELECT * FROM pg_catalog.pg_tables where tablename='libraries';")

--- a/db_migration.py
+++ b/db_migration.py
@@ -15,6 +15,8 @@ def migrate(db_url: str):
 
     Note: This function must be run before the SQLAlchemy session is initialized.
     """
+    # Need to set up some temporary logging since we haven't
+    # had a chance to read the logging config from the DB
     logging.basicConfig()
     log = logging.getLogger(__name__)
     log.setLevel(logging.INFO)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,21 @@
 [[package]]
+name = "alembic"
+version = "1.8.1"
+description = "A database migration tool for SQLAlchemy."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.9\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.9\""}
+Mako = "*"
+SQLAlchemy = ">=1.3.0"
+
+[package.extras]
+tz = ["python-dateutil"]
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.1"
 description = "Atomic file writes."
@@ -288,7 +305,7 @@ python-versions = ">=3.5"
 name = "importlib-metadata"
 version = "4.12.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -300,6 +317,21 @@ zipp = ">=0.5"
 docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
 perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+
+[[package]]
+name = "importlib-resources"
+version = "5.10.0"
+description = "Read resources from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -363,6 +395,23 @@ cssselect = ["cssselect (>=0.7)"]
 html5 = ["html5lib"]
 htmlsoup = ["BeautifulSoup4"]
 source = ["Cython (>=0.29.7)"]
+
+[[package]]
+name = "Mako"
+version = "1.2.3"
+description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+MarkupSafe = ">=0.9.2"
+
+[package.extras]
+babel = ["Babel"]
+lingua = ["lingua"]
+testing = ["pytest"]
 
 [[package]]
 name = "markupsafe"
@@ -727,7 +776,7 @@ python-versions = ">=3.7"
 name = "typing-extensions"
 version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -804,7 +853,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 name = "zipp"
 version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -819,9 +868,13 @@ pg-binary = ["psycopg2-binary"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "4d7d85355f26c0b2ecd899a17f7e94969f954c2891286acfbe4574031d5e55cc"
+content-hash = "5d9f6156cfb8b578242b9c69e2d706d3f181a80038a80f3aedf2e049148080f5"
 
 [metadata.files]
+alembic = [
+    {file = "alembic-1.8.1-py3-none-any.whl", hash = "sha256:0a024d7f2de88d738d7395ff866997314c837be6104e90c5724350313dee4da4"},
+    {file = "alembic-1.8.1.tar.gz", hash = "sha256:cd0b5e45b14b706426b833f06369b9a6d5ee03f826ec3238723ce8caaf6e5ffa"},
+]
 atomicwrites = [
     {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
 ]
@@ -990,6 +1043,10 @@ importlib-metadata = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
+importlib-resources = [
+    {file = "importlib_resources-5.10.0-py3-none-any.whl", hash = "sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437"},
+    {file = "importlib_resources-5.10.0.tar.gz", hash = "sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668"},
+]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -1081,6 +1138,10 @@ lxml = [
     {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:c852b1530083a620cb0de5f3cd6826f19862bafeaf77586f1aef326e49d95f0c"},
     {file = "lxml-4.9.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:287605bede6bd36e930577c5925fcea17cb30453d96a7b4c63c14a257118dbb9"},
     {file = "lxml-4.9.1.tar.gz", hash = "sha256:fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"},
+]
+Mako = [
+    {file = "Mako-1.2.3-py3-none-any.whl", hash = "sha256:c413a086e38cd885088d5e165305ee8eed04e8b3f8f62df343480da0a385735f"},
+    {file = "Mako-1.2.3.tar.gz", hash = "sha256:7fde96466fcfeedb0eed94f187f20b23d85e4cb41444be0e542e2c8c65c396cd"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ repository = "https://github.com/ThePalaceProject/library-registry"
 version = "0" # Version number is managed with tags in git
 
 [tool.poetry.dependencies]
+alembic = "^1.8.1"
 aws-xray-sdk = "<2.11"
 bcrypt = "3.2.0"
 feedparser = "*"

--- a/testing.py
+++ b/testing.py
@@ -57,7 +57,7 @@ class DatabaseTest(object):
     @classmethod
     def get_database_connection(cls):
         url = Configuration.database_url(test=True)
-        engine, connection = SessionManager.initialize(url)
+        engine, connection = SessionManager.initialize(url, testing=True)
 
         return engine, connection
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2008,8 +2008,10 @@ class TestDBMigrate(DatabaseTest):
         cfg = Config("alembic.ini")
         ensure_version(cfg)
 
+        # Remove any alembic versions that existed from previous tests
+        cursor.execute("DELETE from alembic_version")
         # Set a fake alembic version, ensuring the 'upgrade' will fail
-        cursor.execute("UPDATE alembic_version SET version_num = 'xxxxx'")
+        cursor.execute("INSERT INTO alembic_version(version_num) VALUES ('xxxxx')")
         conn.commit()
 
         # This will not raise an error

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,13 +1,18 @@
 import datetime
 import json
 import random
+from unittest import mock
 
+import psycopg2
 import pytest
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import MultipleResultsFound
 
+from alembic.command import ensure_version
+from alembic.config import Config
 from config import Configuration
+from db_migration import migrate
 from emailer import Emailer
 from model import (
     Admin,
@@ -1965,3 +1970,52 @@ class TestAdmin(DatabaseTest):
         # Now that there's an admin, subsequent attempts to make a new admin won't work.
         another_admin = Admin.authenticate(self._db, "Another", "password")
         assert another_admin is None
+
+
+class TestDBMigrate(DatabaseTest):
+    @mock.patch("db_migration.psycopg2.connect")
+    @mock.patch("db_migration.stamp")
+    @mock.patch("db_migration.upgrade")
+    def test_migrate(self, mock_upgrade, mock_stamp, mock_connect):
+        fetchone = mock_connect().cursor().fetchone
+
+        # New DB, No tables
+        # Should just 'stamp head'
+        fetchone.return_value = None
+        migrate("postgresql://...")
+        assert mock_stamp.call_count == 1
+        assert mock_upgrade.call_count == 0
+
+        mock_upgrade.reset_mock()
+        mock_stamp.reset_mock()
+
+        # Existing DB, Tables available
+        # Should attempt to run an upgrade
+        fetchone.return_value = ("public", "libraries", None, None)
+        migrate("postgresql://...")
+        assert mock_stamp.call_count == 0
+        assert mock_upgrade.call_count == 1
+
+    def test_migrate_bad_stamp(self):
+        """Test the alembic migration with a stamp that does not exist.
+        This might happen when a rollback occurs and the stamp is of the rolled-back change
+        """
+        url = Configuration.database_url(test=True)
+        conn = psycopg2.connect(url)
+        cursor = conn.cursor()
+
+        # Create the alembic table
+        cfg = Config("alembic.ini")
+        ensure_version(cfg)
+
+        # Set a fake alembic version, ensuring the 'upgrade' will fail
+        cursor.execute("UPDATE alembic_version SET version_num = 'xxxxx'")
+        conn.commit()
+
+        # This will not raise an error
+        # But it will not change the "head" either
+        migrate(url)
+
+        cursor.execute("SELECT * from alembic_version")
+        version = cursor.fetchone()
+        assert version == ("xxxxx",)


### PR DESCRIPTION
## Description
There is no autogenerated first version migration file, since all models are up-to-date
<!--- Describe your changes -->

## Motivation and Context
The Library registry has no formal method of migrating the DB schema within (or without) the codebase. As with the CM, it is recommended to use Alembic to allow auto-generated and reversible migration scripts.

[Notion](https://www.notion.so/lyrasis/Library-Registry-Use-Alembic-for-DB-migrations-7025232dd9024e388cb128ef84990d3b)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually autogenerated and tested some alembic scripts with fake changes using `alembic revision --autogenerate`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
