### PR TITLE
Update the connection string we use in CI to remove warning.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands =
     pytest {posargs:tests}
 passenv = SIMPLIFIED_* CI
 setenv =
-    docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9015/simplified_registry_test
+    docker: SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:test@localhost:9015/simplified_registry_test
 docker =
     docker: db-registry
 allowlist_externals = poetry


### PR DESCRIPTION
## Description

Small change to connection string, fixes warning when we run our tests.
