### PR TITLE
Setup detailed version endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Hidden files / folders
+.*
+
+# Temp files
+*~
+
+# Readmes
+**/*.md
+
+# Tests
+tests/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Mac OS
+.DS_Store

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -65,9 +65,37 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install Poetry
+        uses: ThePalaceProject/circulation/.github/actions/poetry@main
+        with:
+          version: "1.3.2"
+
+      - name: Setup Dunamai
+        run: poetry install --only ci
+        env:
+          POETRY_VIRTUALENVS_CREATE: false
+
+      - name: Create version file
+        run: |
+          echo "__version__ = '$(dunamai from git --style semver)'" >> admin/_version.py
+          echo "__commit__ = '$(dunamai from git --format {commit} --full-commit)'" >> admin/_version.py
+          echo "__branch__ = '$(dunamai from git --format {branch})'" >> admin/_version.py
+
 
       - name: Login to the Docker registry
         uses: docker/login-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 .env
 
 .vscode
+
+# Our dynamically generated version file
+admin/_version.py

--- a/admin/__init__.py
+++ b/admin/__init__.py
@@ -1,0 +1,18 @@
+# These constants are put into a _version.py file by the
+# docker build. If they are present, then we want to import
+# them here, so they can be used by the application.
+
+try:
+    from admin._version import __version__
+except (ModuleNotFoundError, ImportError):
+    __version__ = None
+
+try:
+    from admin._version import __commit__
+except (ModuleNotFoundError, ImportError):
+    __commit__ = None
+
+try:
+    from admin._version import __branch__
+except (ModuleNotFoundError, ImportError):
+    __branch__ = None

--- a/admin/config.py
+++ b/admin/config.py
@@ -49,13 +49,21 @@ class Configuration:
         )
 
     @classmethod
-    def _package_name(cls) -> str:
+    def package_name(cls) -> str:
         """Get the effective package name.
 
         :return: A package name.
         :rtype: str
         """
         return os.environ.get(cls.ENV_ADMIN_UI_PACKAGE_NAME) or cls.PACKAGE_NAME
+
+    @classmethod
+    def package_version(cls) -> str:
+        """Get the effective package version.
+
+        :return: Package version.
+        """
+        return os.environ.get(cls.ENV_ADMIN_UI_PACKAGE_VERSION) or cls.PACKAGE_VERSION
 
     @classmethod
     def lookup_asset_url(
@@ -94,11 +102,8 @@ class Configuration:
         :rtype: str
         """
         operational_mode = _operational_mode or cls.operational_mode()
-        version = (
-            os.environ.get(cls.ENV_ADMIN_UI_PACKAGE_VERSION) or cls.PACKAGE_VERSION
-        )
         template = cls.PACKAGE_TEMPLATES[operational_mode]["package_url"]
-        url = template.format(name=cls._package_name(), version=version)
+        url = template.format(name=cls.package_name(), version=cls.package_version())
         if not url.endswith("/"):
             url += "/"
         return url
@@ -115,7 +120,7 @@ class Configuration:
         base_dir = _base_dir or cls.ADMIN_DIRECTORY
         return os.path.join(
             base_dir,
-            cls.DEVELOPMENT_MODE_PACKAGE_TEMPLATE.format(name=cls._package_name()),
+            cls.DEVELOPMENT_MODE_PACKAGE_TEMPLATE.format(name=cls.package_name()),
         )
 
     @classmethod

--- a/app.py
+++ b/app.py
@@ -223,10 +223,22 @@ def coverage():
     return app.library_registry.coverage_controller.lookup()
 
 
+@app.route("/version.json")
+def application_version():
+    return app.library_registry.version.version()
+
+
+# TODO: This route is deprecated and should be removed in a
+#       future release of the code, it has been left here for
+#       one release to ease any deployment issues.
 @app.route("/heartbeat")
 @returns_problem_detail
 def hearbeat():
-    return app.library_registry.heartbeat.heartbeat()
+    version_info = application_version()
+    version_info[
+        "WARNING"
+    ] = "The /heartbeat endpoint is deprecated. Please use /version.json instead."
+    return version_info
 
 
 # Adobe Vendor ID implementation

--- a/controller.py
+++ b/controller.py
@@ -42,7 +42,7 @@ from problem_details import (
     UNABLE_TO_NOTIFY,
 )
 from registrar import LibraryRegistrar
-from util.app_server import HeartbeatController, catalog_response
+from util.app_server import ApplicationVersionController, catalog_response
 from util.http import HTTP
 from util.problem_detail import ProblemDetail
 from util.string_helpers import base64, random_string
@@ -73,7 +73,7 @@ class LibraryRegistry:
         self.validation_controller = ValidationController(self)
         self.coverage_controller = CoverageController(self)
         self.static_files = StaticFileController(self)
-        self.heartbeat = HeartbeatController()
+        self.version = ApplicationVersionController()
         vendor_id, node_value, delegates = Configuration.vendor_id(self._db)
         if vendor_id:
             self.adobe_vendor_id = AdobeVendorIDController(

--- a/tests/util/test_app_server.py
+++ b/tests/util/test_app_server.py
@@ -1,0 +1,53 @@
+import pytest
+from flask import Flask, make_response
+
+import admin
+from admin.config import Configuration as AdminUiConfig
+from util.app_server import ApplicationVersionController
+
+
+@pytest.mark.parametrize(
+    "version,commit,branch,ui_version,ui_package",
+    [("123", "xyz", "abc", "def", "ghi"), (None, None, None, None, None)],
+)
+def test_application_version_controller(
+    version, commit, branch, ui_version, ui_package, monkeypatch
+):
+
+    # Mock the cm version strings
+    monkeypatch.setattr(admin, "__version__", version)
+    monkeypatch.setattr(admin, "__commit__", commit)
+    monkeypatch.setattr(admin, "__branch__", branch)
+
+    # Mock the admin ui version strings
+    if ui_package:
+        monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, ui_package)
+    else:
+        monkeypatch.delenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, raising=False)
+
+    if ui_version:
+        monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, ui_version)
+    else:
+        monkeypatch.delenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, raising=False)
+
+    with Flask(__name__).test_request_context("/version.json"):
+        response = make_response(ApplicationVersionController.version())
+
+    assert response.status_code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+
+    assert response.json["version"] == version
+    assert response.json["commit"] == commit
+    assert response.json["branch"] == branch
+
+    # When the env are not set (None) we use defaults
+    assert (
+        response.json["admin_ui"]["package"] == ui_package
+        if ui_package
+        else AdminUiConfig.PACKAGE_NAME
+    )
+    assert (
+        response.json["admin_ui"]["version"] == ui_version
+        if ui_version
+        else AdminUiConfig.PACKAGE_VERSION
+    )

--- a/util/app_server.py
+++ b/util/app_server.py
@@ -10,6 +10,8 @@ from flask_babel import lazy_gettext as _
 from lxml import etree
 from psycopg2 import DatabaseError
 
+import admin
+from admin.config import Configuration as AdminUiConfig
 from opds import OPDSCatalog
 from util.problem_detail import ProblemDetail
 
@@ -129,6 +131,16 @@ class ErrorHandler:
         return response
 
 
-class HeartbeatController:
-    def heartbeat(self):
-        return make_response("", 200, {"Content-Type": "application/json"})
+class ApplicationVersionController:
+    @staticmethod
+    def version():
+        response = {
+            "version": admin.__version__,
+            "commit": admin.__commit__,
+            "branch": admin.__branch__,
+            "admin_ui": {
+                "package": AdminUiConfig.package_name(),
+                "version": AdminUiConfig.package_version(),
+            },
+        }
+        return response


### PR DESCRIPTION
## Description

This PR adds a new endpoint `version.json` to the library registry, similar to the PR that added the same functionality to the circulation manager https://github.com/ThePalaceProject/circulation/pull/765. This new `version.json` endpoint replaces the old `healthcheck` endpoint. This endpoint returns version information for the circulation manager instance, and for the admin UI. This is currently helpful, but will be even more helpful when we are doing more rapid deployments, so that we can check what version is deployed where.

The new endpoint returns something like this:
```json
{
  "admin_ui": {
    "package": "@thepalaceproject/circulation-admin",
    "version": "0.4.2"
  },
  "branch": "main",
  "commit": "00f33eb39163937cfe864537124a43058e216a57",
  "version": "1.0.1"
}
```

The version is derived from the git tag by [Dunamai](https://github.com/mtkennerly/dunamai). If the commit is not a tagged version, it will create a version number based on the distance from the last tagged version and the commit hash. Something like `1.0.2-post.51+00f33eb39`.

## Motivation and Context

Same context and motivation as the CM PR.

## How Has This Been Tested?

- Running unit tests locally & in CI

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
