### PR TITLE
Bump registry admin verison

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -11,7 +11,7 @@ class OperationalMode(str, Enum):
 class Configuration:
 
     PACKAGE_NAME = "@thepalaceproject/library-registry-admin"
-    PACKAGE_VERSION = "0.0.2"
+    PACKAGE_VERSION = "0.1.0"
 
     STATIC_ASSETS = {
         "admin_js": "library-registry-admin.js",

--- a/admin/config.py
+++ b/admin/config.py
@@ -11,7 +11,7 @@ class OperationalMode(str, Enum):
 class Configuration:
 
     PACKAGE_NAME = "@thepalaceproject/library-registry-admin"
-    PACKAGE_VERSION = "0.1.0"
+    PACKAGE_VERSION = "0.0.3"
 
     STATIC_ASSETS = {
         "admin_js": "library-registry-admin.js",


### PR DESCRIPTION
## Description

This PR updates the registry admin interface version to use v0.0.3

Release notes here: 
https://github.com/ThePalaceProject/library-registry-admin/releases/tag/v0.0.3

## Motivation and Context

Let us deploy newest registry admin code

## How Has This Been Tested?

Started containers with `docker-compose` and made sure I could see admin interface.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
