### PR TITLE
Add dunamai

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -340,6 +340,21 @@ ssh = ["paramiko (>=2.4.2)"]
 tls = ["cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=17.5.0)"]
 
 [[package]]
+name = "dunamai"
+version = "1.16.0"
+description = "Dynamic version generation"
+category = "dev"
+optional = false
+python-versions = ">=3.5,<4.0"
+files = [
+    {file = "dunamai-1.16.0-py3-none-any.whl", hash = "sha256:dc92d817f3bc155e8b129e8c705c36bb15a7e950e2698a93aea142732a888e98"},
+    {file = "dunamai-1.16.0.tar.gz", hash = "sha256:bfe8e23cc5a1ceed1c7f791674ea24cf832a53a5da73f046eeb43367ccfc3f77"},
+]
+
+[package.dependencies]
+packaging = ">=20.9"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.0.0rc9"
 description = "Backport of PEP 654 (exception groups)"
@@ -1854,4 +1869,4 @@ pg-binary = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "cc886d63af5127f4bebc4386530f1b985cd8348b66ab7aa9e1c0c3f2f963269b"
+content-hash = "7f3ba969eb30bbf05ec2f49530236cab001ec290606ca4c1f0eeda2ae36da868"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pg = ["psycopg2"]
 pg-binary = ["psycopg2-binary"]
 
 [tool.poetry.group.ci.dependencies]
+dunamai = "^1.16.0"
 pre-commit = "~2.21"
 tox = "^3.26.0"
 tox-docker = "^3.1.0"


### PR DESCRIPTION
## Description

In https://github.com/ThePalaceProject/library-registry/pull/163 I goofed a bit when adding the detailed version endpoint. I got everything setup, but I failed to add `dunamai` as a dependency. So the deployed images aren't getting the proper info in the `version.json` as you can see here: 
https://registry.dev.palaceproject.io/version.json

On the plus side, watchtower is working for CD because it deployed these changes out last night. 

## Motivation and Context

Fixing version endpoint for registry.

## How Has This Been Tested?

Don't have a good way to test this, but based on the errors reported from CI
https://github.com/ThePalaceProject/library-registry/actions/runs/4253805590/jobs/7399273932#step:9:16

And the fact dunamai wasn't added to pyproject.toml. I'm fairly confident that this will work. Once CI runs on this PR, we can see if those errors are still reported.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
