### PR TITLE
Fix supervisord timeouts on long migrations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ For a production environment:
 poetry install --only main,pg
 ```
 
+### Initialize the database
+
+To initialize a fresh database (ie no tables yet created) use the following script:
+
+```shell
+poetry run ./bin/migrate_database
+```
+
+### Upgrade/Downgrade an existing database
+
+During development you may wish to use Alembic to upgrade or downgrade to a particular database version.
+You can fulfill this desire using the `-u/--upgrade <version>` or `-d/--downgrade <version>` parameters, respectively.
+For example to upgrade to version "ee43af3" you would execute the following command:
+
+```shell
+poetry run ./bin/migrate_database -u ee43af3
+```
+
+Database versions can be found in the alembic/versions directory.
+
 ### Running the Registry
 
 To start the registry inside the virtualenv that `poetry` creates:

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ uses_location = uses_location_factory(app)
 
 testing = "TESTING" in os.environ
 db_url = Configuration.database_url(testing)
-SessionManager.initialize(db_url, testing=testing)
+SessionManager.initialize(db_url)
 session_factory = SessionManager.sessionmaker(db_url)
 _db = flask_scoped_session(session_factory, app)
 

--- a/bin/migrate_database
+++ b/bin/migrate_database
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Initialize or migrate database with Alembic"""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from scripts import AlembicMigrateDatabase
+
+AlembicMigrateDatabase().run()

--- a/db_migration.py
+++ b/db_migration.py
@@ -1,13 +1,15 @@
 import logging
+import os
 
 import psycopg2
 
 from alembic.command import stamp, upgrade
 from alembic.config import Config
 from alembic.util.exc import CommandError
+from config import Configuration
 
 
-def migrate(db_url: str):
+def migrate(db_url: str = None):
     """Ensure the alembic migration state is up-to-date.
     If the database table "libraries" has not been created yet, we can assume this is a new deployment.
     Else, we can assume this database should attempt an upgrade to the latest version, if the DB
@@ -15,6 +17,10 @@ def migrate(db_url: str):
 
     Note: This function must be run before the SQLAlchemy session is initialized.
     """
+
+    if not db_url:
+        db_url = Configuration.database_url("TESTING" in os.environ)
+
     # Need to set up some temporary logging since we haven't
     # had a chance to read the logging config from the DB
     logging.basicConfig()

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,19 +1,32 @@
 #!/bin/sh
 
 ##############################################################################
-# Wait for the database to be ready before starting the servers
+# Wait for the database to be ready and migrated before starting the servers
 ##############################################################################
 
 PG_READY=""
 PG_READY_WAIT_SECONDS=5
 COUNT=0
 RETRIES=10
+MIGRATION_COMPLETE=""
 
 pg_is_ready () {
     python > /dev/null 2>&1 <<EOF
 import os,sys,psycopg2
 try:
   psycopg2.connect(os.environ.get('SIMPLIFIED_PRODUCTION_DATABASE'))
+except Exception:
+  sys.exit(1)
+sys.exit(0)
+EOF
+}
+
+migrate_db () {
+    python > /dev/null 2>&1 <<EOF
+import sys
+from db_migration import migrate
+try:
+  migrate()
 except Exception:
   sys.exit(1)
 sys.exit(0)
@@ -33,14 +46,27 @@ until [ -n "$PG_READY" ] || [ $COUNT -gt $RETRIES ]; do
     fi
 done
 
+if  [ -n "$PG_READY" ]; then
+    echo "--- Ready to begin database migration."
+    migrate_db
+
+    if [ $? -eq 0 ]; then
+        MIGRATION_COMPLETE="true"
+        echo "--- The database migration completed successfully."
+    fi
+fi
 ##############################################################################
 # Start the Supervisor process that manages Nginx and Gunicorn, with
 # a webpack file watcher for the front end if we're in dev mode.
 ##############################################################################
 
-if [ -n "$PG_READY" ]; then
+if [ -n "$PG_READY" ] && [ -n"$MIGRATION_COMPLETE" ]; then
     exec /usr/local/bin/supervisord -c /etc/supervisord.conf
 else
-    echo "Database never became available, exiting!"
+    if [ -n "$PG_READY" ]; then
+      echo "Database never became available, exiting!"
+    else
+      echo "Database migration did not complete successfully: exiting!"
+    fi
     exit 1
 fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -22,15 +22,7 @@ EOF
 }
 
 migrate_db () {
-    python > /dev/null 2>&1 <<EOF
-import sys
-from db_migration import migrate
-try:
-  migrate()
-except Exception:
-  sys.exit(1)
-sys.exit(0)
-EOF
+    ./bin/migrate_database > /dev/null 2>&1
 }
 
 until [ -n "$PG_READY" ] || [ $COUNT -gt $RETRIES ]; do

--- a/model.py
+++ b/model.py
@@ -51,7 +51,6 @@ from sqlalchemy.sql.expression import (
 )
 
 from config import Configuration
-from db_migration import migrate
 from emailer import Emailer
 from util import GeometryUtility
 from util.language import LanguageCodes
@@ -103,22 +102,16 @@ class SessionManager:
         return sessionmaker(bind=engine)
 
     @classmethod
-    def initialize(cls, url: str, testing=False) -> tuple[Engine, Connection]:
+    def initialize(cls, url: str) -> tuple[Engine, Connection]:
         """Initialize the database connection
         Create all the database tables from the models
         Optionally, run the alembic migration scripts
-
-        :param db_url: The Database connection url
-        :param testing: Whether we are in a test environment or not"""
+        :param db_url: The Database connection url"""
         if url in cls.engine_for_url:
             engine = cls.engine_for_url[url]
             return engine, engine.connect()
 
         engine = cls.engine(url)
-
-        # Run the migrations only if we're not TESTING
-        if not testing:
-            migrate(url)
 
         Base.metadata.create_all(engine)
 

--- a/scripts.py
+++ b/scripts.py
@@ -6,8 +6,6 @@ import sys
 
 import db_migration
 from adobe_vendor_id import AdobeVendorIDClient
-from alembic.command import downgrade, upgrade
-from alembic.config import Config as AlembicConfig
 from alembic.util import CommandError
 from authentication_document import AuthenticationDocument
 from config import Configuration
@@ -724,14 +722,14 @@ class AlembicMigrateDatabase(Script):
 
     def do_run(self, cmd_args=None):
         args = self.parse_command_line(cmd_args=cmd_args)
-        config = AlembicConfig("alembic.ini")
-
         try:
             if args.downgrade is not None:
-                downgrade(config, args.downgrade)
-            elif args.upgrade is not None:
-                upgrade(config, args.upgrade)
+                action = "downgrade"
+                version = args.downgrade
             else:
-                db_migration.migrate()
+                action = "upgrade"
+                version = "head" if args.upgrade is None else args.upgrade
+
+            db_migration.migrate(action=action, version=version)
         except CommandError as e:
             print(f"Error: {e}. No migrations performed.")

--- a/testing.py
+++ b/testing.py
@@ -57,7 +57,7 @@ class DatabaseTest:
     @classmethod
     def get_database_connection(cls):
         url = Configuration.database_url(test=True)
-        engine, connection = SessionManager.initialize(url, testing=True)
+        engine, connection = SessionManager.initialize(url)
 
         return engine, connection
 


### PR DESCRIPTION
## Description
This update ensures that the database initialization and migration occurs before the web application comes up.
When running docker-compose,  the migration occurs before supervisord spawns gunicorn and, in so doing, prevents timeouts and restarts when migrations take longer than usual (which they legitimately do under certain circumstances).

So in a nutshell:

1.  Move alembic database initialization and migration out of `model` initialization code and into a separate script.
2. For docker compose, Invoke the database initialization/migration before attempting to start the web application.
3. Document changes in the README.md.

## Motivation and Context
https://www.notion.so/lyrasis/Library-registry-times-out-and-kills-long-running-migrations-b4e3bc913df340ee812b5178d248d0f1

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested the docker compose setup to confirm that it works post changes.
Manually tested standing up a local instance after running the migration script. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
