### PR TITLE
Revert b0087a2a58546b84b69dc68f62fb4ec052f04abf :  tox-docker upgrade.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1620,18 +1620,18 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psu
 
 [[package]]
 name = "tox-docker"
-version = "4.1.0"
+version = "4.0.0"
 description = "Launch a docker instance around test runs"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "tox-docker-4.1.0.tar.gz", hash = "sha256:0317e692dc80f2197eaf9c905dcb8d1d1f9d5bf2686ecfd83c22a1da9d23fb24"},
-    {file = "tox_docker-4.1.0-py2.py3-none-any.whl", hash = "sha256:444c72192a2443d2b4db5766545d4413ea683cc488523d770e2e216f15fa3086"},
+    {file = "tox-docker-4.0.0.tar.gz", hash = "sha256:c0b259a6f14fcb68f8e767926aa1d9e6649eb11862444ba704b5cacf93e4e937"},
+    {file = "tox_docker-4.0.0-py2.py3-none-any.whl", hash = "sha256:84a260b8e8096d2bb5e2115d8a75cac33b183e1b5d0ef341302e64971a562731"},
 ]
 
 [package.dependencies]
-docker = ">=4.0,<7.0"
+docker = ">=2.3.0,<6.0"
 packaging = "*"
 tox = ">=3.0.0,<5.0"
 


### PR DESCRIPTION
## Description
Revert the commit that was causing the web container to fail when running `make up-watch`
<!--- Describe your changes -->

## Motivation and Context
https://www.notion.so/lyrasis/Library-registry-bcrypt-_bcrypt-circular-dependency-issue-on-Docker-a0a0138fdace4653b30699eb20dd7936?pvs=4
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Before this PR,  updating the registry results in the errors detailed in the ticket referenced above.

To verify the PR works I did the following:
```
make clean;
make build;
make up-watch
```
Verified that the previous error messages were not coming up. 
Then opened `http://localhost/admin` to verify that the webapp is functional.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
