### PR TITLE
Prevent creation of admins when username unknown

### DIFF
--- a/model.py
+++ b/model.py
@@ -2704,12 +2704,16 @@ class Admin(Base):
         :return: Admin or None
         """
         setting_up = _db.query(Admin).count() == 0
-        admin, is_new = get_one_or_create(_db, Admin, username=username)
+
         if setting_up:
+            admin, ignore = create(_db, Admin, username=username)
             admin.password = cls.make_password(password)
             return admin
-        elif not is_new and admin and admin.check_password(password):
-            return admin
+        else:
+            admin: Admin = get_one(_db, Admin, username=username)
+            if admin and admin.check_password(password):
+                return admin
+
         return None
 
     def __repr__(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1959,6 +1959,13 @@ class TestAdmin(DatabaseTest):
         # Unsuccessfully authenticate existing admin
         assert Admin.authenticate(self._db, "Admin", "wrong") is None
 
+    def test_authenticate_and_verify_no_new_admins_were_created(self):
+        assert Admin.authenticate(self._db, "Admin", "123") == self.admin
+        before_count = self._db.query(Admin).count()
+        assert Admin.authenticate(self._db, "any_username", "any_password") is None
+        after_count = self._db.query(Admin).count()
+        assert before_count == after_count
+
     def test_make_new_admin(self):
         # Create the first admin
         self._db.delete(self.admin)


### PR DESCRIPTION
## Description
While testing the registry I noticed that  logging in using a username that is not in the database causes a record to be created with an empty password hash.  Attempting to log in with the same credentials then results in a 500 since attempts to validate a user with no password hash breaks the authentication. 

This PR ensures that a new admin user is created only when there are no admins in the database (ie on first access).  After that logging in with a random user and password does not result in a new admin user being added to the database.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Notion](https://www.notion.so/lyrasis/500-error-logging-into-library-registry-9cc219bb91d64aec86d66ee3461ed51e)
## How Has This Been Tested?
Manually tested and unit test verifies fix.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
