### PR TITLE
PP-493 Removed the before first request dependency

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,11 @@ else:
         app.library_registry = LibraryRegistry(_db)
 
 
-@app.before_first_request
+def initialize(arbiter):
+    """To be called by gunicorn on server startup"""
+    set_secret_key()
+
+
 def set_secret_key(_db=None):
     _db = _db or app._db
     app.secret_key = ConfigurationSetting.sitewide_secret(_db, Configuration.SECRET_KEY)
@@ -327,4 +331,5 @@ if __name__ == "__main__":
         port = 80
 
     app.library_registry.log.info("Starting app on %s:%s", host, port)
+    initialize(None)
     app.run(debug=debug, host=host, port=port)

--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -4,9 +4,9 @@ import os
 # The `LIBRARY_REGISTRY_DOCKER_HOME` environment variables is set in the
 # `Dockerfile`. It contains the value of the app directory.
 APP_HOME = os.environ.get("LIBRARY_REGISTRY_DOCKER_HOME")
-
 # Shared Settings
 wsgi_app = "app:app"
+when_ready = "app.initialize"
 accesslog = "-"
 errorlog = "-"
 loglevel = "info"

--- a/tests/util/test_xray.py
+++ b/tests/util/test_xray.py
@@ -1,6 +1,9 @@
 from unittest.mock import MagicMock, call
 
-from util.xray import PalaceXrayUtils
+from pytest import MonkeyPatch
+
+from app import app
+from util.xray import PalaceXrayMiddleware, PalaceXrayUtils
 
 
 class TestPalaceXrayUtils:
@@ -38,6 +41,7 @@ class TestPalaceXrayUtils:
         monkeypatch.setattr("util.xray.PalaceXrayMiddleware", mock_middleware)
 
         # Nothing happens if env isn't set
+        monkeypatch.delenv(PalaceXrayUtils.XRAY_ENV_ENABLE)
         PalaceXrayUtils.configure_app(mock_app)
         assert PalaceXrayUtils.setup_xray.called is False
         assert mock_middleware.called is False
@@ -53,3 +57,24 @@ class TestPalaceXrayUtils:
         PalaceXrayUtils.configure_app(mock_app)
         assert PalaceXrayUtils.setup_xray.called is True
         assert mock_middleware.called is True
+
+
+class TestPalaceXrayMiddleware:
+    def test_before_request(self, monkeypatch: MonkeyPatch):
+        mock_app = MagicMock()
+        mock_app._xray_first_request_done = None
+        mock_recorder = MagicMock()
+        xray = PalaceXrayMiddleware(mock_app, mock_recorder)
+
+        # First request does additional setup
+        with app.test_request_context("/") as ctx:
+            xray._before_request()
+            assert mock_app._xray_first_request_done == True
+            assert mock_recorder.current_segment().put_annotation.call_count == 2
+            assert ctx.request._palace_first_request == True
+
+        # Second request only calls put_annotation once
+        with app.test_request_context("/") as ctx:
+            xray._before_request()
+            assert getattr(ctx.request, "_palace_first_request", None) is None
+            assert mock_recorder.current_segment().put_annotation.call_count == 3

--- a/util/xray.py
+++ b/util/xray.py
@@ -57,9 +57,6 @@ class PalaceXrayMiddleware(XRayMiddleware):
     def __init__(self, app: Flask, recorder: AWSXRayRecorder):
         super().__init__(app, recorder)
 
-        # Add an additional hook to before first request
-        self.app.before_first_request(self._before_first_request)
-
     def _before_first_request(self):
         self._before_request()
         segment = self._recorder.current_segment()
@@ -69,8 +66,14 @@ class PalaceXrayMiddleware(XRayMiddleware):
         request._palace_first_request = True
 
     def _before_request(self):
+        if getattr(self.app, "_xray_first_request_done", None) is None:
+            # First request so we do first request processing
+            setattr(self.app, "_xray_first_request_done", True)
+            self._before_first_request()
+
         if getattr(request, "_palace_first_request", None) is not None:
             # If we are in the first request this work is already done
             return
+
         super()._before_request()
         PalaceXrayUtils.put_annotations(self._recorder.current_segment(), "registry")


### PR DESCRIPTION
## Description
As a substitute Gunicorn will do some setup when the server is ready 
And the AWS Xray will push some setup into every request processing

<!--- Describe your changes -->

## Motivation and Context
In order to upgrade the flask version we must remove before_first_request dependencies
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested locally by running gunicorn with and without xray.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
