### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ EXPOSE 5432
 #  * Copies in the config files for Gunicorn, Nginx, and Supervisor
 #  * Sets the container entrypoint, which is a script that starts Supervisor
 
-FROM python:3.9.16-alpine3.17 AS builder
+FROM python:3.10-alpine3.17 AS builder
 
 EXPOSE 80
 


### PR DESCRIPTION
## Description

Upgrade to Python 3.10. 

## Motivation and Context

Lines up our Python version with the Circulation image, so we are using Python 3.10 everywhere.

See circ PR: 
https://github.com/ThePalaceProject/circulation/pull/1462

## How Has This Been Tested?

Built docker image locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
