### PR TITLE
[PP-1832] Require SSL when talking to postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
     ports:
       - "80:80"
     environment:
-      - SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:simplified_test@libreg_local_db:5433/simplified_registry_test
-      - SIMPLIFIED_PRODUCTION_DATABASE=postgresql://simplified:simplified@libreg_local_db:5433/simplified_registry_dev
+      - SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:simplified_test@libreg_local_db:5433/simplified_registry_test?sslmode=require
+      - SIMPLIFIED_PRODUCTION_DATABASE=postgresql://simplified:simplified@libreg_local_db:5433/simplified_registry_dev?sslmode=require
       - FLASK_ENV=development
       - AWS_ACCESS_KEY_ID=TEST
       - AWS_SECRET_ACCESS_KEY=testpassword

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
     SIMPLIFIED_*
     CI
 setenv =
-    docker: SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:test@localhost:9015/simplified_registry_test
+    docker: SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:test@localhost:9015/simplified_registry_test?sslmode=require
     docker: AWS_ACCESS_KEY_ID=TEST
     docker: AWS_SECRET_ACCESS_KEY=testpassword
     docker: SIMPLIFIED_AWS_S3_ENDPOINT_URL=http://localhost:9004


### PR DESCRIPTION
## Description

Updates the docker compose database connection strings to use the "required" sslmode.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1832
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated tests should still pass.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
