### PR TITLE
Test Python 3.12 in CI

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. This prevents duplicated runs on internal PRs.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,11 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
         args:
-          - --py38-plus
+          - --py310-plus
 
   - repo: https://github.com/myint/autoflake
     rev: v2.0.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A discovery service for matching people to the libraries that serve them.
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-![Python: 3.8,3.9,3.10,3.11](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
+![Python: 3.10,3.11,3.12](https://img.shields.io/badge/Python-3.10%20%7C%203.11%20%7C%203.12-blue)
 
 This is a [LYRASIS](http://lyrasis.org)-maintained fork of the NYPL
 [Library Simplified](http://www.librarysimplified.org/) Library Registry.
@@ -132,7 +132,7 @@ To install the registry locally, you'll need the following:
 
 - PostgreSQL 16+
 - PostGIS 3
-- Python 3.8+ (3.9 is the build target for the Docker install)
+- Python 3.10+
 - Appropriate system dependencies to build the Python dependencies, which may include:
     - `make` / `gcc` / `build-essential` (debian) / `build-base` (alpine) / XCode CLI Tools (mac)
     - Compression libs like `bzip2-dev`, `zlib-dev`, etc.
@@ -268,18 +268,17 @@ flag.
 
 | Environment | Python Version |
 |-------------|----------------|
-| py38        | Python 3.8     |
-| py39        | Python 3.9     |
 | py310       | Python 3.10    |
 | py311       | Python 3.11    |
+| py312       | Python 3.12    |
 
 All of these environments are tested by default when running tox. To test one specific environment you can use the `-e`
 flag.
 
-Test Python 3.8
+Test Python 3.10
 
 ```shell
-tox -e py38
+tox -e py310
 ```
 
 You need to have the Python versions you are testing against installed on your local system. `tox` searches the system
@@ -299,10 +298,10 @@ on Github Actions. `tox-docker` is installed automatically as part of the `ci` p
 The docker functionality is included in a `docker` factor that can be added to the environment. To run an environment
 with a particular factor you add it to the end of the environment.
 
-Test with Python 3.8 using docker containers for the services.
+Test with Python 3.10 using docker containers for the services.
 
 ```shell
-tox -e py38-docker
+tox -e py310-docker
 ```
 
 #### Override `pytest` arguments

--- a/tests/admin/test_config.py
+++ b/tests/admin/test_config.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 import pytest
 
@@ -9,7 +8,7 @@ from admin.config import OperationalMode
 
 class TestAdminUI:
     @staticmethod
-    def _set_env(key: str, value: Optional[str]):
+    def _set_env(key: str, value: str | None):
         if value:
             os.environ[key] = value
         elif key in os.environ:
@@ -43,8 +42,8 @@ class TestAdminUI:
     )
     def test_package_url(
         self,
-        package_name: Optional[str],
-        package_version: Optional[str],
+        package_name: str | None,
+        package_version: str | None,
         mode: OperationalMode,
         expected_result_startswith: str,
     ):
@@ -71,8 +70,8 @@ class TestAdminUI:
     )
     def test_package_development_directory(
         self,
-        package_name: Optional[str],
-        package_version: Optional[str],
+        package_name: str | None,
+        package_version: str | None,
         expected_result: str,
     ):
         self._set_env("TPP_LIBRARY_REGISTRY_ADMIN_PACKAGE_NAME", package_name)

--- a/tests/fixtures/controller.py
+++ b/tests/fixtures/controller.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 from flask import Flask

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -3,8 +3,8 @@ import os
 import shutil
 import tempfile
 import time
+from collections.abc import Generator, Iterable
 from datetime import datetime
-from typing import Generator, Iterable, Optional, Tuple
 
 import pytest as pytest
 import sqlalchemy
@@ -69,7 +69,7 @@ class DatabaseFixture:
         self._connection = connection
 
     @staticmethod
-    def _get_database_connection() -> Tuple[Engine, Connection]:
+    def _get_database_connection() -> tuple[Engine, Connection]:
         url = Configuration.database_url(test=True)
         engine, connection = SessionManager.initialize(url)
         return engine, connection
@@ -93,7 +93,7 @@ class DatabaseTransactionFixture:
     """A fixture representing a single transaction. The transaction is automatically rolled back."""
 
     _database: DatabaseFixture
-    _default_library: Optional[Library]
+    _default_library: Library | None
     _session: Session
     _transaction: Transaction
     _counter: int

--- a/tests/test_emailer.py
+++ b/tests/test_emailer.py
@@ -1,7 +1,6 @@
 import os
 import quopri
 from email.mime.text import MIMEText
-from typing import Optional
 from unittest import mock
 
 import pytest
@@ -81,7 +80,7 @@ class MockBrokenEmailer(Emailer):
 
 class TestEmailer:
     @staticmethod
-    def _set_env(key: str, value: Optional[str]):
+    def _set_env(key: str, value: str | None):
         if value:
             os.environ[key] = value
         elif key in os.environ:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-docker
+envlist = py{310,311,312}-docker
 skipsdist = true
 
 [testenv]
@@ -50,7 +50,6 @@ host_var =
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312

--- a/util/xray.py
+++ b/util/xray.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import Optional
 
 from aws_xray_sdk.core import AWSXRayRecorder
 from aws_xray_sdk.core import patch as xray_patch
@@ -17,9 +16,7 @@ class PalaceXrayUtils:
     XRAY_ENV_ANNOTATE = "PALACE_XRAY_ANNOTATE_"
 
     @classmethod
-    def put_annotations(
-        cls, segment: Optional[Segment], seg_type: Optional[str] = None
-    ):
+    def put_annotations(cls, segment: Segment | None, seg_type: str | None = None):
         if seg_type is not None:
             segment.put_annotation("type", seg_type)
 


### PR DESCRIPTION
## Description

- Run tests against Python 3.12.
- Drop support for Python 3.8, 3.9 since we don't support them anywhere else
- Update the `pyupgrade` hook for py310. A couple automated type hint changes came in via this change.

## Motivation and Context

Make sure we are compatible for upgrade when the time comes 🚀 

Similar to: https://github.com/ThePalaceProject/circulation/pull/2146

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
