### PR TITLE
Better handle OPDS server root content types. (PP-1959)

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -93,7 +93,7 @@ class OPDSCatalog:
                     url_for=url_for,
                     include_logo=include_logos,
                     web_client_uri_template=web_client_uri_template,
-                    include_service_area=include_service_areas
+                    include_service_area=include_service_areas,
                 )
             )
         annotator.annotate_catalog(self, live=live)

--- a/opds.py
+++ b/opds.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import flask
@@ -7,6 +9,7 @@ from sqlalchemy.orm import Query
 from authentication_document import AuthenticationDocument
 from config import Configuration
 from model import ConfigurationSetting, Hyperlink, LibraryType, Validation
+from util.http import NormalizedMediaType
 
 
 class Annotator:
@@ -37,6 +40,9 @@ class OPDSCatalog:
     FOCUS_REL = "http://librarysimplified.org/rel/registry/focus"
 
     CACHE_TIME = 3600 * 12
+
+    _NORMALIZED_OPDS2_TYPE = NormalizedMediaType(OPDS_TYPE)
+    _NORMALIZED_OPDS1_TYPE = NormalizedMediaType(OPDS_1_TYPE)
 
     @classmethod
     def _strftime(cls, date):
@@ -93,6 +99,18 @@ class OPDSCatalog:
         annotator.annotate_catalog(self, live=live)
 
     @classmethod
+    def is_opds1_type(cls, media_type: str | None) -> bool:
+        return cls._NORMALIZED_OPDS1_TYPE.min_match(media_type)
+
+    @classmethod
+    def is_opds2_type(cls, media_type: str | None) -> bool:
+        return cls._NORMALIZED_OPDS2_TYPE.min_match(media_type)
+
+    @classmethod
+    def is_opds_type(cls, media_type: str | None) -> bool:
+        return cls.is_opds1_type(media_type) or cls.is_opds2_type(media_type)
+
+    @classmethod
     def _feed_is_large(cls, _db, libraries):
         """Determine whether a prospective feed is 'large' per a sitewide setting.
 
@@ -125,7 +143,6 @@ class OPDSCatalog:
         web_client_uri_template=None,
         include_service_area=False,
     ):
-
         """Create an OPDS catalog for a library.
 
         :param distance: The distance, in meters, from the client's

--- a/registrar.py
+++ b/registrar.py
@@ -180,10 +180,9 @@ class LibraryRegistrar:
                     opds_url=opds_url,
                     auth_url=auth_url,
                 )
-        elif content_type not in (OPDSCatalog.OPDS_TYPE, OPDSCatalog.OPDS_1_TYPE):
+        elif not OPDSCatalog.is_opds_type(content_type):
             failure_detail = _(
-                "Supposed root document at %(url)s is not an OPDS document",
-                url=opds_url,
+                f"Supposed root document at {opds_url} does not appear to be an OPDS document (content_type={content_type!r}).",
             )
         elif not self.opds_response_links_to_auth_document(opds_response, auth_url):
             failure_detail = _(
@@ -316,14 +315,14 @@ class LibraryRegistrar:
         if link:
             links.append(link.get("url"))
         media_type = response.headers.get("Content-Type")
-        if media_type == OPDSCatalog.OPDS_TYPE:
+        if OPDSCatalog.is_opds2_type(media_type):
             # Parse as OPDS 2.
             catalog = json.loads(response.content)
             links = []
             for k, v in catalog.get("links", {}).items():
                 if k == rel:
                     links.append(v.get("href"))
-        elif media_type == OPDSCatalog.OPDS_1_TYPE:
+        elif OPDSCatalog.is_opds1_type(media_type):
             # Parse as OPDS 1.
             feed = feedparser.parse(response.content)
             for link in feed.get("feed", {}).get("links", []):

--- a/util/http.py
+++ b/util/http.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
 import urllib.parse
+from dataclasses import dataclass
 
 import requests
 from flask_babel import lazy_gettext as _
@@ -425,3 +428,56 @@ class HTTP:
                 response.content,
             )
         )
+
+
+@dataclass
+class NormalizedMediaType:
+    """Represents a normalized HTTP media type with its type prefix and directives.
+
+    This class provides methods to normalize a media type string into a canonical form
+    and compare media types.
+
+    TODO: Parsing is currently very lenient, and will accept media types with missing
+     or malformed directives.
+    """
+
+    string: str
+
+    def __post_init__(self):
+        self.prefix, self.directives = self._from_string(self.string)
+
+    @staticmethod
+    def _from_string(media_type: str):
+        elements = media_type.split(";")
+        prefix = elements.pop(0)
+        directives = {
+            k.strip(): v.strip()
+            for k, v in (
+                directive.split("=", 1) for directive in elements if "=" in directive
+            )
+            if k.strip()
+        }
+        return prefix, directives
+
+    def min_match(self, other: NormalizedMediaType | str | None) -> bool:
+        """Determine whether another media type is a 'minimum match' for this one.
+
+        :param other: The other media type to compare with this one.
+        :return: True if the other media type is a minimum match for this one, False otherwise.
+
+        A minimum match here is a media type that matches the prefix and
+        directives of this one, but may or may not have additional directives.
+        """
+        if other is None:
+            return False
+        if isinstance(other, str):
+            other = NormalizedMediaType(other)
+
+        if self.prefix != other.prefix:
+            return False
+        for k, v in self.directives.items():
+            if k not in other.directives:
+                return False
+            if other.directives[k] != v:
+                return False
+        return True

--- a/util/http.py
+++ b/util/http.py
@@ -385,7 +385,7 @@ class HTTP:
             make_request_with,
             http_method,
             process_response_with=cls.process_debuggable_response,
-            **kwargs
+            **kwargs,
         )
 
     @classmethod


### PR DESCRIPTION
## Description

- Loosens content media type checking from exact string match to matching on a type prefix and a minimal set of type directives.
- Adds a normalized media type class that can be applied to other URL matching in the future.
- Adds some test cases to cover some that were previously missing.

NB: ~Note that some linter checks failed. The linter was changing some things that were unrelated to this PR, so I removed them for now. Once this PR is reviewed, I'll add the changes from the linter.~ I have added these changes.

## Motivation and Context

[Palace Manager #2142](https://github.com/ThePalaceProject/circulation/pull/2142) introduced a change in the feed content types and this PR is aimed at catching up with those changes.

[Jira [PP-1959](https://ebce-lyrasis.atlassian.net/browse/PP-1959)]

## How Has This Been Tested?

- Tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/library-registry/actions/runs/12168589049) pass.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1959]: https://ebce-lyrasis.atlassian.net/browse/PP-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ