### PR TITLE
Bump poetry version to match dependabot

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Poetry
         uses: ThePalaceProject/circulation/.github/actions/poetry@main
         with:
-          version: "1.5.1"
+          version: "2.1.1"
 
       - name: Install Pre-commit
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV NGINX_VERSION=1.23.3
 ENV NJS_VERSION=0.7.9
 ENV PKG_RELEASE=1
 ENV SUPERVISOR_VERSION=4.2.2
-ENV POETRY_VERSION=1.5.1
+ENV POETRY_VERSION=2.1.1
 ENV POETRY_URL="https://install.python-poetry.org"
 ENV POETRY_HOME="/etc/poetry"
 # required for postgres ssl: the crt file doesn't exist


### PR DESCRIPTION
## Description

Bump up the Poetry version we are using to match what dependabot uses.

CM PR: https://github.com/ThePalaceProject/circulation/pull/2403

## Motivation and Context

I've noticed some messages in our CI lately that the lock file version may not be supported, since dependabot has moved to a 2.x version of Poetry.

## How Has This Been Tested?

- Build in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
