### PR TITLE
Update our pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,13 +39,13 @@ repos:
         name: Run black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: Run isort
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.31.1
+    rev: 0.33.0
     hooks:
       - id: check-github-workflows
       - id: check-github-actions
@@ -58,7 +58,7 @@ repos:
         files: pyproject.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.27
+    rev: v0.9.29
     hooks:
       - id: pymarkdown
         args:

--- a/model.py
+++ b/model.py
@@ -29,9 +29,9 @@ from sqlalchemy import (
     Unicode,
     UniqueConstraint,
     create_engine,
+    exc as sa_exc,
+    func,
 )
-from sqlalchemy import exc as sa_exc
-from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError, MultipleResultsFound, NoResultFound
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = ["poetry-core>=1.0.0"]
 [tool]
 
 [tool.isort]
+combine_as_imports = true
 profile = "black"
 
 [tool.poetry]

--- a/tests/admin/test_config.py
+++ b/tests/admin/test_config.py
@@ -2,8 +2,7 @@ import os
 
 import pytest
 
-from admin.config import Configuration as AdminConfig
-from admin.config import OperationalMode
+from admin.config import Configuration as AdminConfig, OperationalMode
 
 
 class TestAdminUI:

--- a/util/http.py
+++ b/util/http.py
@@ -7,8 +7,10 @@ from dataclasses import dataclass
 import requests
 from flask_babel import lazy_gettext as _
 
-from .problem_detail import JSON_MEDIA_TYPE as PROBLEM_DETAIL_JSON_MEDIA_TYPE
-from .problem_detail import ProblemDetail as pd
+from .problem_detail import (
+    JSON_MEDIA_TYPE as PROBLEM_DETAIL_JSON_MEDIA_TYPE,
+    ProblemDetail as pd,
+)
 
 INTEGRATION_ERROR = pd(
     "http://librarysimplified.org/terms/problem/remote-integration-failed",

--- a/util/xray.py
+++ b/util/xray.py
@@ -1,9 +1,7 @@
 import logging
 import os
 
-from aws_xray_sdk.core import AWSXRayRecorder
-from aws_xray_sdk.core import patch as xray_patch
-from aws_xray_sdk.core import xray_recorder
+from aws_xray_sdk.core import AWSXRayRecorder, patch as xray_patch, xray_recorder
 from aws_xray_sdk.core.models.segment import Segment
 from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
 from aws_xray_sdk.ext.httplib import add_ignored as httplib_add_ignored


### PR DESCRIPTION
## Description

Updates our pre-commit linters. Figured I would do this while updating poetry.

## Motivation and Context

This PR was created by running:
```
pre-commit autoupdate
pre-commit run -a
```

So all the changes are automated from our linters.  I also added the `combine_as_imports` isort option to match the changes to CM.

Similar to: https://github.com/ThePalaceProject/circulation/pull/2411

## How Has This Been Tested?

- Running CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
