### PR TITLE
Add cache-control header to auth document requests (PP-2380)

### DIFF
--- a/registrar.py
+++ b/registrar.py
@@ -271,7 +271,10 @@ class LibraryRegistrar:
             allowed_codes.append(401)
         try:
             response = self.do_get(
-                url, allowed_response_codes=allowed_codes, timeout=30
+                url,
+                allowed_response_codes=allowed_codes,
+                timeout=30,
+                headers={"Cache-Control": "no-cache"},
             )
             # We only allowed 404 above so that we could return a more
             # specific problem detail document if it happened.

--- a/tests/test_registrar.py
+++ b/tests/test_registrar.py
@@ -352,3 +352,23 @@ class TestRegistrar:
         assert type(args[0][1]) == BytesIO
 
         assert library.logo_url == "http://localhost/logo"
+
+    def test__make_request(self, db: DatabaseTransactionFixture) -> None:
+        mock_get = MagicMock()
+        registrar = LibraryRegistrar(db.session, do_get=mock_get)
+        response = registrar._make_request(
+            "http://test.com/registration",
+            "http://test.com/auth",
+            "Uh oh 404",
+            "Uh oh timeout",
+            "Uh oh exception",
+        )
+
+        mock_get.assert_called_once_with(
+            "http://test.com/auth",
+            allowed_response_codes=["2xx", "3xx", 404],
+            timeout=30,
+            headers={"Cache-Control": "no-cache"},
+        )
+
+        assert response == mock_get.return_value


### PR DESCRIPTION
## Description

Make sure we send along a cache-control header when we make a request to retrieve a CM auth document during registration. 

## Motivation and Context

Related CM PR: https://github.com/ThePalaceProject/circulation/pull/2417
Jira: PP-2380

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
