### PR TITLE
A testing job to docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,16 +110,85 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # TODO: Add a job to test the image before we push it to the registry
-  # We already do this in the circulation images. Its a bit more complicated here
-  # because of the structure of the docker containers and docker-compose file.
-  # It would be nice make these more consistent across the different projects, so
-  # we can reuse the same testing setup.
+  test:
+    name: Integration test (${{ matrix.arch.name }})
+    runs-on: ${{ matrix.arch.runner }}
+    needs: [build]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: "amd64"
+            runner: "ubuntu-24.04"
+# This is disabled for now, as the postgis/postgis image does not support arm64
+# we should eventually figure out a solution for this so we can test on all platforms
+#          - name: "arm64"
+#            runner: "ubuntu-24.04-arm"
+
+    services:
+      postgres:
+        image: postgis/postgis:16-3.5
+        env:
+          POSTGRES_USER: palace
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: registry
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}
+          pattern: digests-${{ matrix.arch.name }}
+
+      - name: Set image
+        working-directory: ${{ runner.temp }}/digests-${{ matrix.arch.name }}
+        run: |
+          IMAGE="${{needs.build.outputs.repo}}$(printf '@sha256:%s' *)"
+          echo "$IMAGE"
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Pull & Start containers
+        run: >
+          docker run
+          --name registry
+          -d -p 8080:80
+          --network ${{ job.services.postgres.network }}
+          -e "SIMPLIFIED_PRODUCTION_DATABASE=postgresql://palace:test@postgres:5432/registry"
+          ${IMAGE}
+
+      - name: Test webserver is running
+        run: |
+          timeout 240s grep -q 'gunicorn entered RUNNING state' <(docker logs registry -f 2>&1)
+          healthcheck=$(curl --write-out "%{http_code}" --silent --output /dev/null http://localhost:8080/version.json)
+          if ! [[ ${healthcheck} == "200" ]]; then
+            echo "  ERROR: Unexpected status code: ${healthcheck}"
+            curl -v http://localhost:8080/version.json
+            exit 1
+          else
+            echo "  OK"
+          fi
+
+      - name: Output logs
+        if: failure()
+        run: docker logs registry
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f registry
 
   push:
     name: Tag & Push Images
     runs-on: ubuntu-24.04
-    needs: [build]
+    needs: [test, build]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,8 @@ jobs:
       - name: Test webserver is running
         run: |
           timeout 240s grep -q 'gunicorn entered RUNNING state' <(docker logs registry -f 2>&1)
+          timeout 240s grep -q 'nginx entered RUNNING state' <(docker logs registry -f 2>&1)
+          timeout 240s grep -q 'Booting worker' <(docker logs registry -f 2>&1)
           healthcheck=$(curl --write-out "%{http_code}" --silent --output /dev/null http://localhost:8080/version.json)
           if ! [[ ${healthcheck} == "200" ]]; then
             echo "  ERROR: Unexpected status code: ${healthcheck}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,9 +167,7 @@ jobs:
 
       - name: Test webserver is running
         run: |
-          timeout 240s grep -q 'gunicorn entered RUNNING state' <(docker logs registry -f 2>&1)
-          timeout 240s grep -q 'nginx entered RUNNING state' <(docker logs registry -f 2>&1)
-          timeout 240s grep -q 'Booting worker' <(docker logs registry -f 2>&1)
+          timeout 60s grep -q 'Booting worker' <(docker logs registry -f 2>&1)
           healthcheck=$(curl --write-out "%{http_code}" --silent --output /dev/null http://localhost:8080/version.json)
           if ! [[ ${healthcheck} == "200" ]]; then
             echo "  ERROR: Unexpected status code: ${healthcheck}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         read_only: true
 
   libreg_minio:
-    container_name: libreg_minio
+    container_name: minio
     image: bitnami/minio:2022.3.3
     ports:
       - "9000:9000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         read_only: true
 
   libreg_minio:
-    container_name: minio
+    container_name: libreg_minio
     image: bitnami/minio:2022.3.3
     ports:
       - "9000:9000"


### PR DESCRIPTION
## Description

Add a build step to test that our docker container starts and we can at least do a curl to get the `version.json` file.

## Motivation and Context

This should help avoid issues like https://github.com/ThePalaceProject/library-registry/pull/823 from making it into a docker build.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
