### PR TITLE
Use shared github-actions repo for poetry and jira-release-sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: ThePalaceProject/circulation/.github/actions/poetry@main
+        uses: ThePalaceProject/github-actions/poetry@v1
         with:
           version: "2.2.1"
 

--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Sync release to Jira
-        uses: ThePalaceProject/circulation/.github/actions/jira-release-sync@main
+        uses: ThePalaceProject/github-actions/jira-release-sync@v1
         with:
           jira-base-url: ${{ secrets.JIRA_BASE_URL }}
           jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -6,9 +6,6 @@ jobs:
   sync-to-jira:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
       - name: Sync release to Jira
         uses: ThePalaceProject/github-actions/jira-release-sync@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Poetry
-        uses: ThePalaceProject/circulation/.github/actions/poetry@main
+        uses: ThePalaceProject/github-actions/poetry@v1
         with:
           version: "2.2.1"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: ThePalaceProject/circulation/.github/actions/poetry@main
+        uses: ThePalaceProject/github-actions/poetry@v1
         with:
           version: "2.2.1"
 


### PR DESCRIPTION
## Description

Point the `poetry` and `jira-release-sync` action references in our workflows at the new `ThePalaceProject/github-actions` repo, pinned to the `v1` tag.

Affected workflows:
- `.github/workflows/build.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/test.yml`
- `.github/workflows/jira-release-sync.yml`

## Motivation and Context

The reusable `poetry` and `jira-release-sync` actions have been moved out of `ThePalaceProject/circulation/.github/actions/` and into a dedicated `ThePalaceProject/github-actions` repo so they can be shared across projects. This PR switches this repo's workflows over to the new source.

## How Has This Been Tested?

- Verified the action paths resolve in the new repo (`poetry/` and `jira-release-sync/` exist at the root of `ThePalaceProject/github-actions`).
- CI on this PR will exercise the updated `lint`, `test`, and `build` workflows against the new action source.
- The `jira-release-sync` workflow only runs on release publish, so it will be validated on the next release.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.