### PR TITLE
Add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,10 @@
+name: Claude PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: ThePalaceProject/github-actions/.github/workflows/claude-review.yml@v1
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Description

Adds a `claude-review` GitHub workflow that calls the shared reusable workflow at [`ThePalaceProject/github-actions/.github/workflows/claude-review.yml@v1`](https://github.com/ThePalaceProject/github-actions). This wires up automated Claude code review for PRs in this repo, mirroring the setup landed in [virtual-library-card#845](https://github.com/ThePalaceProject/virtual-library-card/pull/845) and [circulation#3312](https://github.com/ThePalaceProject/circulation/pull/3312).

## Motivation and Context

We want the same automated Claude PR review that the circulation and virtual-library-card repos now use to run against PRs in this repo as well. Using the shared reusable workflow keeps the configuration centralized so future updates land in one place.

## How Has This Been Tested?

- Pre-commit (including the GitHub workflow validator) passes.
- The workflow itself will not review this PR — Claude only runs against PRs once the workflow is on `main`, to prevent prompt-injection attacks via PR-introduced workflow changes. End-to-end behaviour will verify on the next PR opened after this merges.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.