### PR TITLE
Endpoint deprecation decorator (PP-4490)

### DIFF
--- a/src/palace/registry/util/flask_util.py
+++ b/src/palace/registry/util/flask_util.py
@@ -87,11 +87,7 @@ def deprecated(
                     f'<{urljoin(request.host_url, replacement)}>; rel="successor-version"'
                 )
             if link_parts:
-                new_link = ", ".join(link_parts)
-                existing = response.headers.get("Link")
-                response.headers["Link"] = (
-                    f"{existing}, {new_link}" if existing else new_link
-                )
+                response.headers.add("Link", ", ".join(link_parts))
             return response
 
         return wrapper

--- a/src/palace/registry/util/flask_util.py
+++ b/src/palace/registry/util/flask_util.py
@@ -2,8 +2,12 @@
 
 import ipaddress
 import re
+from datetime import datetime
+from functools import wraps
+from urllib.parse import urljoin
 
-from flask import Response, request
+from flask import Response, make_response, request
+from werkzeug.http import http_date
 
 from palace.registry.util import problem_detail
 from palace.registry.util.language import languages_from_accept
@@ -32,6 +36,67 @@ IPV4_REGEX = re.compile(
                           """,
     re.VERBOSE,
 )
+
+
+def deprecated(
+    *,
+    deprecation_date: datetime | None = None,
+    sunset: datetime | None = None,
+    documentation: str | None = None,
+    replacement: str | None = None,
+):
+    """Mark a route as deprecated, injecting standardized HTTP response headers.
+
+    The approach follows the mapping proposed in the OpenAPI discussion
+    "proposal:OpenAPI 3.3 Proposal: API-Level Deprecation & Sunset Support":
+    https://github.com/OAI/OpenAPI-Specification/discussions/5193
+
+    ``Deprecation: true`` is always emitted; when ``deprecation_date`` is
+    provided its value is used instead of the boolean.
+
+    :param deprecation_date: When the endpoint was (or will be) deprecated.
+        Emitted as ``Deprecation: <IMF-fixdate>`` (RFC 9745 §2).
+    :param sunset: Date after which the endpoint may be removed.
+        Emitted as ``Sunset: <HTTP-date>`` (RFC 8594).
+    :param documentation: URL of a resource describing the deprecation context.
+        Emitted as ``Link: <url>; rel="deprecation"`` (RFC 9745 §3.1).
+    :param replacement: URL of the replacement endpoint.
+        Emitted as ``Link: <url>; rel="successor-version"`` (RFC 5829).
+    """
+    if deprecation_date is not None and deprecation_date.tzinfo is None:
+        raise ValueError("deprecation_date must be timezone-aware")
+    if sunset is not None and sunset.tzinfo is None:
+        raise ValueError("sunset must be timezone-aware")
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            response = make_response(f(*args, **kwargs))
+            response.headers["Deprecation"] = (
+                http_date(deprecation_date) if deprecation_date else "true"
+            )
+            if sunset is not None:
+                response.headers["Sunset"] = http_date(sunset)
+            link_parts = []
+            if documentation is not None:
+                link_parts.append(
+                    f'<{urljoin(request.host_url, documentation)}>; rel="deprecation"'
+                )
+            if replacement is not None:
+                link_parts.append(
+                    f'<{urljoin(request.host_url, replacement)}>; rel="successor-version"'
+                )
+            if link_parts:
+                new_link = ", ".join(link_parts)
+                existing = response.headers.get("Link")
+                response.headers["Link"] = (
+                    f"{existing}, {new_link}" if existing else new_link
+                )
+            return response
+
+        return wrapper
+
+    return decorator
 
 
 def problem_raw(type, status, title, detail=None, instance=None, headers=None):

--- a/tests/registry/util/test_flask_util.py
+++ b/tests/registry/util/test_flask_util.py
@@ -1,11 +1,13 @@
+import datetime
 import ipaddress
 import re
 
 import pytest
-from flask import Flask, request
+from flask import Flask, Response, request
 
 from palace.registry.util.flask_util import (
     IPV4_REGEX,
+    deprecated,
     is_public_ipv4_address,
     originating_ip,
 )
@@ -165,3 +167,132 @@ class TestFlaskUtil:
             "url", headers=headers, environ_base={"REMOTE_ADDR": remote_address}
         ):
             assert originating_ip() == expected_address
+
+
+class TestDeprecated:
+    """Tests for the deprecated() route decorator."""
+
+    def _route(self, **kwargs):
+        """Return a decorated route function using the given deprecated() kwargs."""
+
+        @deprecated(**kwargs)
+        def route():
+            return Response("ok", 200)
+
+        return route
+
+    @pytest.mark.parametrize(
+        "deprecation_date, expected",
+        [
+            pytest.param(None, "true", id="no-date"),
+            pytest.param(
+                datetime.datetime(2025, 6, 1, tzinfo=datetime.UTC),
+                "Sun, 01 Jun 2025 00:00:00 GMT",
+                id="with-date",
+            ),
+        ],
+    )
+    def test_deprecation_header_value(
+        self, generic_app_obj, deprecation_date, expected
+    ):
+        """Deprecation header is 'true' when no date is given, or an IMF-fixdate (RFC 9745 §2)."""
+        route = self._route(deprecation_date=deprecation_date)
+        with generic_app_obj.test_request_context("/"):
+            assert route().headers["Deprecation"] == expected
+
+    def test_sunset_header_when_provided(self, generic_app_obj):
+        """Sunset header is emitted when sunset is given."""
+        date = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+        route = self._route(sunset=date)
+        with generic_app_obj.test_request_context("/"):
+            assert route().headers["Sunset"] == "Thu, 01 Jan 2026 00:00:00 GMT"
+
+    def test_no_sunset_header_when_omitted(self, generic_app_obj):
+        """Sunset header is absent when no sunset date is given."""
+        route = self._route()
+        with generic_app_obj.test_request_context("/"):
+            assert "Sunset" not in route().headers
+
+    @pytest.mark.parametrize(
+        "kwarg, path, expected_rel",
+        [
+            pytest.param(
+                "documentation",
+                "/deprecation-info",
+                'rel="deprecation"',
+                id="documentation",
+            ),
+            pytest.param(
+                "replacement",
+                "/new?x=1",
+                'rel="successor-version"',
+                id="replacement",
+            ),
+        ],
+    )
+    def test_link_header_when_provided(
+        self, generic_app_obj, kwarg, path, expected_rel
+    ):
+        """Link header is emitted for documentation (RFC 9745 §3.1) and replacement (RFC 5829)."""
+        route = self._route(**{kwarg: path})
+        with generic_app_obj.test_request_context("/"):
+            link = route().headers["Link"]
+        assert expected_rel in link
+        assert f"http://localhost{path}" in link
+
+    def test_both_link_parts_combined_in_single_header(self, generic_app_obj):
+        """documentation and replacement are combined into a single Link header."""
+        route = self._route(documentation="/docs", replacement="/new")
+        with generic_app_obj.test_request_context("/"):
+            link = route().headers["Link"]
+        assert 'rel="deprecation"' in link
+        assert 'rel="successor-version"' in link
+        # Both must appear in the same header value, not as separate headers.
+        assert isinstance(link, str)
+
+    def test_existing_link_header_is_preserved(self, generic_app_obj):
+        """Pre-existing Link header values are not clobbered."""
+
+        @deprecated(replacement="/new")
+        def route():
+            r = Response("ok", 200)
+            r.headers["Link"] = '</existing>; rel="related"'
+            return r
+
+        with generic_app_obj.test_request_context("/"):
+            link = route().headers["Link"]
+        assert 'rel="related"' in link
+        assert 'rel="successor-version"' in link
+
+    def test_applies_to_error_responses(self, generic_app_obj):
+        """Deprecation is a property of the endpoint, not the result — added to error responses too."""
+
+        @deprecated()
+        def route():
+            return Response("not found", 404)
+
+        with generic_app_obj.test_request_context("/"):
+            assert route().headers["Deprecation"] == "true"
+
+    def test_applies_to_non_response_return(self, generic_app_obj):
+        """Headers are injected even when the route returns a plain string instead of a Response."""
+
+        @deprecated()
+        def route():
+            return "ok"
+
+        with generic_app_obj.test_request_context("/"):
+            assert route().headers["Deprecation"] == "true"
+
+    @pytest.mark.parametrize(
+        "kwarg",
+        [
+            pytest.param("deprecation_date", id="deprecation-date"),
+            pytest.param("sunset", id="sunset"),
+        ],
+    )
+    def test_naive_datetime_raises(self, kwarg):
+        """Timezone-naive datetimes are rejected at decoration time."""
+        naive = datetime.datetime(2025, 6, 1)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            deprecated(**{kwarg: naive})

--- a/tests/registry/util/test_flask_util.py
+++ b/tests/registry/util/test_flask_util.py
@@ -260,9 +260,25 @@ class TestDeprecated:
             return r
 
         with generic_app_obj.test_request_context("/"):
-            link = route().headers["Link"]
-        assert 'rel="related"' in link
-        assert 'rel="successor-version"' in link
+            links = " ".join(route().headers.getlist("Link"))
+        assert 'rel="related"' in links
+        assert 'rel="successor-version"' in links
+
+    def test_multiple_existing_link_headers_are_preserved(self, generic_app_obj):
+        """All pre-existing Link headers survive when the response carries more than one."""
+
+        @deprecated(replacement="/new")
+        def route():
+            r = Response("ok", 200)
+            r.headers.add("Link", '</existing1>; rel="related"')
+            r.headers.add("Link", '</existing2>; rel="prev"')
+            return r
+
+        with generic_app_obj.test_request_context("/"):
+            links = " ".join(route().headers.getlist("Link"))
+        assert 'rel="related"' in links
+        assert 'rel="prev"' in links
+        assert 'rel="successor-version"' in links
 
     def test_applies_to_error_responses(self, generic_app_obj):
         """Deprecation is a property of the endpoint, not the result — added to error responses too."""


### PR DESCRIPTION
## Description

Adds a `deprecated()` decorator for marking routes as deprecated. When applied to a route, it injects standardized HTTP headers into every response:

- `Deprecation: true` (or an IMF-fixdate if a date is provided) — RFC 9745 §2
- `Sunset: <HTTP-date>` — RFC 8594
- `Link: <url>; rel="deprecation"` — RFC 9745 §3.1
- `Link: <url>; rel="successor-version"` — RFC 5829

All parameters are optional and keyword-only. `documentation` and `replacement` paths are resolved against the request host URL, and any pre-existing `Link` headers are preserved rather than overwritten.

If this is generally useful, we might consider 

## Motivation and Context

Provides a consistent, RFC-compliant (-ish, it at least [seems to be community aligned](https://github.com/OAI/OpenAPI-Specification/discussions/5193)) way to signal endpoint deprecation to API consumers via standard HTTP headers, rather than relying on documentation alone or one-off header injection in individual controllers.

[Jira PP-4490]

## How Has This Been Tested?

- New test cases added to cover this new functionality.
- Manual experimentation in local dev environment.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/library-registry/actions/runs/26833511838) pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

