### PR TITLE
Pin alpine image version to fix broken nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,12 @@ EXPOSE 5432
 #  * Copies in the config files for Gunicorn, Nginx, and Supervisor
 #  * Sets the container entrypoint, which is a script that starts Supervisor
 
+# Pinned to a specific Alpine version because nginx.org does not always publish
+# (at least not in a timely manner) APK packages for the latest Alpine release.
+# Thus, the untagged `alpine` image can float ahead of what nginx.org supports,
+# breaking our builds.
+# We should periodically update this pin to the newest Alpine version listed at
+# https://nginx.org/packages/alpine/.
 FROM python:3.12-alpine3.21 AS builder
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ EXPOSE 5432
 #  * Copies in the config files for Gunicorn, Nginx, and Supervisor
 #  * Sets the container entrypoint, which is a script that starts Supervisor
 
-FROM python:3.12-alpine AS builder
+FROM python:3.12-alpine3.21 AS builder
 
 EXPOSE 80
 


### PR DESCRIPTION
## Description

Pin the Docker base image to Alpine 3.21 instead of allowing it to use `latest`).

## Motivation and Context

Alpine 3.24 was released recently and `python:3.12-alpine` now resolves to it. The nginx.org package repository does not yet publish packages for Alpine 3.24, causing the Docker build to fail with a 404 when fetching the nginx APK index. This resulted in failing docker builds.

## How Has This Been Tested?

- Running `docker compose build` locally completes successfully with the pinned image.\
- [CI tests](https://github.com/ThePalaceProject/library-registry/actions/runs/27926982555) builds successfully and passes.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
