### PR TITLE
Add `rel` to authentication document link (PP-4299)

### DIFF
--- a/src/palace/registry/opds.py
+++ b/src/palace/registry/opds.py
@@ -536,6 +536,7 @@ class OPDSCatalog:
         if library.authentication_url:
             cls.add_link_to_catalog(
                 catalog,
+                rel=AuthenticationDocument.AUTHENTICATION_DOCUMENT_REL,
                 href=library.authentication_url,
                 type=AuthenticationDocument.MEDIA_TYPE,
             )

--- a/tests/registry/test_opds.py
+++ b/tests/registry/test_opds.py
@@ -507,11 +507,11 @@ class TestOPDSCatalog:
         assert LibraryType.NAME_FOR_CODE[LibraryType.LOCAL] == subject["name"]
 
         [
-            authentication_url,
             web_alternate,
             help,
             eligibility,
             focus,
+            authentication_link,
             opds_self,
             web_self,
         ] = sorted(
@@ -549,9 +549,12 @@ class TestOPDSCatalog:
         assert logo["type"] == "image/png"
         assert logo["href"] == "http://logo-url/"
 
-        assert authentication_url["href"] == library.authentication_url
-        assert "rel" not in authentication_url
-        assert authentication_url["type"] == AuthenticationDocument.MEDIA_TYPE
+        assert authentication_link["href"] == library.authentication_url
+        assert (
+            authentication_link["rel"]
+            == AuthenticationDocument.AUTHENTICATION_DOCUMENT_REL
+        )
+        assert authentication_link["type"] == AuthenticationDocument.MEDIA_TYPE
         # The public Hyperlink was passed into _hyperlink_args,
         # which made it show up in the list of links.
         #


### PR DESCRIPTION
## Description

This adds `rel="http://opds-spec.org/auth/document"` using the pre-existing `AuthenticationDocument.AUTHENTICATION_DOCUMENT_REL` constant.

## Motivation and Context

Authentication document links in registry library catalog entries were missing a `rel` attribute. Without it, clients have no standard way to identify which link in an OPDS entry points to the authentication document. This change makes the link's `rel` consistent with other Palace applications and unambiguous for clients.

[Jira PP-4299]

## How Has This Been Tested?

- Updated test to verify that the `rel` is present.
- Cleaned up a misleading variable name in that test.
- Manual testing to verify the the `rel` is present in feeds.
- Tests pass in local environment.
- CI checks pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
